### PR TITLE
캘린더 기본 UI 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,19 +48,20 @@
     "postcss": "^8.5.6",
     "prettier": "^3.6.2",
     "prettier-plugin-tailwindcss": "^0.6.13",
+    "rollup-plugin-visualizer": "^6.0.3",
     "tailwindcss": "^4.1.11",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.36.0",
-    "vite": "^7.0.3",
-    "rollup-plugin-visualizer": "^6.0.3"
+    "vite": "^7.0.3"
   },
   "dependencies": {
     "axios": "^1.10.0",
+    "dayjs": "^1.11.13",
     "motion": "^12.23.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "tailwind-merge": "^3.3.1",
-    "react-router-dom": "^7.6.3"
+    "react-router-dom": "^7.6.3",
+    "tailwind-merge": "^3.3.1"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [

--- a/packages/design-system/src/components/calendar/Calendar.tsx
+++ b/packages/design-system/src/components/calendar/Calendar.tsx
@@ -28,7 +28,7 @@ export default function Calendar() {
   };
 
   return (
-    <div className='flex w-640 flex-col gap-30 rounded-3xl pt-20 pb-10 shadow-[0px_4px_24px_rgba(156,180,202,0.2)]'>
+    <div className='flex max-w-640 flex-col gap-8 rounded-3xl pt-20 pb-10 md:gap-30 md:shadow-[0px_4px_24px_rgba(156,180,202,0.2)]'>
       <CalendarHeader currentMonth={currentMonth} onNext={handleNextMonth} onPrev={handlePrevMonth} />
       <CalendarGrid currentMonth={currentMonth} />
     </div>

--- a/packages/design-system/src/components/calendar/Calendar.tsx
+++ b/packages/design-system/src/components/calendar/Calendar.tsx
@@ -1,9 +1,12 @@
 import dayjs, { Dayjs } from 'dayjs';
 import { useState } from 'react';
 
+import CalendarGrid from './CalendarGrid';
 import CalendarHeader from './CalendarHeader';
 
+// Calendar 최상위 컴포넌트
 export default function Calendar() {
+  // 현재 월 상태관리
   const [currentMonth, setCurrentMonth] = useState<Dayjs>(dayjs());
 
   const handlePrevMonth = () => {
@@ -16,6 +19,7 @@ export default function Calendar() {
   return (
     <div className='flex w-640 flex-col gap-30 rounded-3xl pt-20 pb-10 shadow-sm'>
       <CalendarHeader currentMonth={currentMonth} onNext={handleNextMonth} onPrev={handlePrevMonth} />
+      <CalendarGrid currentMonth={currentMonth} />
     </div>
   );
 }

--- a/packages/design-system/src/components/calendar/Calendar.tsx
+++ b/packages/design-system/src/components/calendar/Calendar.tsx
@@ -1,8 +1,21 @@
 import dayjs, { Dayjs } from 'dayjs';
 import { useState } from 'react';
 
+import CalendarHeader from './CalendarHeader';
+
 export default function Calendar() {
   const [currentMonth, setCurrentMonth] = useState<Dayjs>(dayjs());
 
-  return <div className='flex w-640 flex-col gap-30 rounded-3xl pt-20 pb-10 shadow-sm'>calendar</div>;
+  const handlePrevMonth = () => {
+    setCurrentMonth((prev) => prev.subtract(1, 'month'));
+  };
+  const handleNextMonth = () => {
+    setCurrentMonth((prev) => prev.add(1, 'month'));
+  };
+
+  return (
+    <div className='flex w-640 flex-col gap-30 rounded-3xl pt-20 pb-10 shadow-sm'>
+      <CalendarHeader currentMonth={currentMonth} onNext={handleNextMonth} onPrev={handlePrevMonth} />
+    </div>
+  );
 }

--- a/packages/design-system/src/components/calendar/Calendar.tsx
+++ b/packages/design-system/src/components/calendar/Calendar.tsx
@@ -1,12 +1,23 @@
 import dayjs, { Dayjs } from 'dayjs';
 import { useState } from 'react';
 
-import CalendarGrid from './CalendarGrid';
-import CalendarHeader from './CalendarHeader';
+import CalendarGrid from '@/components/calendar/CalendarGrid';
+import CalendarHeader from '@/components/calendar/CalendarHeader';
 
-// Calendar 최상위 컴포넌트
+/**
+ * Calendar 컴포넌트 (월 단위의 달력을 렌더링하는 최상위 UI 컴포넌트)
+ *
+ * - 현재 월 상태를 관리하며, 이전/다음 달로 이동할 수 있습니다.
+ * - 상단에는 월 이동을 위한 헤더(`CalendarHeader`)가 있고,
+ * - 하단에는 날짜 그리드(`CalendarGrid`)가 표시됩니다.
+ *
+ * @component
+ * @example
+ * ```tsx
+ * <Calendar />
+ * ```
+ */
 export default function Calendar() {
-  // 현재 월 상태관리
   const [currentMonth, setCurrentMonth] = useState<Dayjs>(dayjs());
 
   const handlePrevMonth = () => {
@@ -17,7 +28,7 @@ export default function Calendar() {
   };
 
   return (
-    <div className='flex w-640 flex-col gap-30 rounded-3xl pt-20 pb-10 shadow-sm'>
+    <div className='flex w-640 flex-col gap-30 rounded-3xl pt-20 pb-10 shadow-[0px_4px_24px_rgba(156,180,202,0.2)]'>
       <CalendarHeader currentMonth={currentMonth} onNext={handleNextMonth} onPrev={handlePrevMonth} />
       <CalendarGrid currentMonth={currentMonth} />
     </div>

--- a/packages/design-system/src/components/calendar/Calendar.tsx
+++ b/packages/design-system/src/components/calendar/Calendar.tsx
@@ -1,0 +1,8 @@
+import dayjs, { Dayjs } from 'dayjs';
+import { useState } from 'react';
+
+export default function Calendar() {
+  const [currentMonth, setCurrentMonth] = useState<Dayjs>(dayjs());
+
+  return <div className='flex w-640 flex-col gap-30 rounded-3xl pt-20 pb-10 shadow-sm'>calendar</div>;
+}

--- a/packages/design-system/src/components/calendar/CalendarGrid.tsx
+++ b/packages/design-system/src/components/calendar/CalendarGrid.tsx
@@ -47,23 +47,23 @@ export default function CalendarGrid({ currentMonth }: CalendarGridProps) {
   }
 
   return (
-    <div className='text-lg'>
-      <div className='flex border-b border-gray-100 pb-12'>
+    <div className='w-full'>
+      <div className='grid grid-cols-7 border-b border-gray-100 pb-12'>
         {oneLetterWeekdays.map((day, idx) => (
-          <div key={idx} className='flex w-92 justify-center p-12 font-bold text-gray-900'>
+          <div key={idx} className='flex justify-center p-12 text-sm font-bold text-gray-900 md:text-lg'>
             {day}
           </div>
         ))}
       </div>
       <div className='divide-y divide-solid divide-gray-50'>
         {weeks.map((week, idx) => (
-          <div key={idx} className='flex'>
+          <div key={idx} className='grid grid-cols-7'>
             {week.map((day) => {
               const isOtherMonth = day.month() !== currentMonth.month();
               return (
                 <div
                   key={day.format('MM/DD')}
-                  className={`flex h-124 w-92 items-start justify-center p-12 font-medium ${
+                  className={`flex h-104 items-start justify-center p-12 text-xs font-medium md:h-124 md:text-lg ${
                     isOtherMonth ? 'text-gray-300' : 'text-gray-800'
                   }`}
                 >

--- a/packages/design-system/src/components/calendar/CalendarGrid.tsx
+++ b/packages/design-system/src/components/calendar/CalendarGrid.tsx
@@ -1,0 +1,62 @@
+import type { Dayjs } from 'dayjs';
+import dayjs from 'dayjs';
+import localeData from 'dayjs/plugin/localeData';
+
+interface CalendarGridProps {
+  currentMonth: Dayjs;
+}
+dayjs.extend(localeData);
+dayjs.locale('en');
+
+export default function CalendarGrid({ currentMonth }: CalendarGridProps) {
+  // 요일 계산(일~토)
+  const Weekdays = dayjs.weekdays();
+  const oneLetterWeekdays = Weekdays.map((day) => day.charAt(0));
+
+  // 날짜 계산(..1~31..)
+  const startDate = dayjs(currentMonth).startOf('month').startOf('week');
+  const endDate = dayjs(currentMonth).endOf('month').endOf('week');
+
+  const calendarDays = [];
+  let current = startDate;
+  while (!current.isAfter(endDate)) {
+    calendarDays.push(current);
+    current = current.add(1, 'day');
+  }
+
+  const weeks = [];
+  for (let i = 0; i < calendarDays.length; i += 7) {
+    weeks.push(calendarDays.slice(i, i + 7));
+  }
+
+  return (
+    <div className='text-lg'>
+      <div className='flex border-b border-gray-100 pb-12 font-bold'>
+        {oneLetterWeekdays.map((day, idx) => (
+          <div key={idx} className='flex w-92 justify-center p-12'>
+            {day}
+          </div>
+        ))}
+      </div>
+      <div className='divide-y divide-solid divide-gray-50'>
+        {weeks.map((week, i) => (
+          <div key={i} className='flex'>
+            {week.map((day, j) => {
+              const isOtherMonth = day.month() !== currentMonth.month();
+              return (
+                <div
+                  key={j}
+                  className={`flex h-124 w-92 items-stretch justify-center p-12 ${
+                    isOtherMonth ? 'text-gray-300' : 'text-gray-800'
+                  }`}
+                >
+                  {day.date()}
+                </div>
+              );
+            })}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/design-system/src/components/calendar/CalendarGrid.tsx
+++ b/packages/design-system/src/components/calendar/CalendarGrid.tsx
@@ -3,17 +3,34 @@ import dayjs from 'dayjs';
 import localeData from 'dayjs/plugin/localeData';
 
 interface CalendarGridProps {
+  /**
+   * 현재 표시 중인 월 (Dayjs 객체)
+   */
   currentMonth: Dayjs;
 }
+// dayjs 확장 및 로케일 설정
 dayjs.extend(localeData);
 dayjs.locale('en');
 
+/**
+ * CalendarGrid 컴포넌트
+ *
+ * - 전달받은 currentMonth를 기준으로 달력 형태의 날짜 그리드를 구성합니다.
+ * - 주 단위 배열로 분할하여 렌더링하며, 해당 월이 아닌 날짜는 흐리게 표시합니다.
+ *
+ * @component
+ * @param {CalendarGridProps} props
+ * @returns {JSX.Element}
+ *
+ * @example
+ * ```tsx
+ * <CalendarGrid currentMonth={dayjs()} />
+ * ```
+ */
 export default function CalendarGrid({ currentMonth }: CalendarGridProps) {
-  // 요일 계산(일~토)
   const Weekdays = dayjs.weekdays();
   const oneLetterWeekdays = Weekdays.map((day) => day.charAt(0));
 
-  // 날짜 계산(..1~31..)
   const startDate = dayjs(currentMonth).startOf('month').startOf('week');
   const endDate = dayjs(currentMonth).endOf('month').endOf('week');
 
@@ -31,22 +48,22 @@ export default function CalendarGrid({ currentMonth }: CalendarGridProps) {
 
   return (
     <div className='text-lg'>
-      <div className='flex border-b border-gray-100 pb-12 font-bold'>
+      <div className='flex border-b border-gray-100 pb-12'>
         {oneLetterWeekdays.map((day, idx) => (
-          <div key={idx} className='flex w-92 justify-center p-12'>
+          <div key={idx} className='flex w-92 justify-center p-12 font-bold text-gray-900'>
             {day}
           </div>
         ))}
       </div>
       <div className='divide-y divide-solid divide-gray-50'>
-        {weeks.map((week, i) => (
-          <div key={i} className='flex'>
-            {week.map((day, j) => {
+        {weeks.map((week, idx) => (
+          <div key={idx} className='flex'>
+            {week.map((day) => {
               const isOtherMonth = day.month() !== currentMonth.month();
               return (
                 <div
-                  key={j}
-                  className={`flex h-124 w-92 items-stretch justify-center p-12 ${
+                  key={day.format('MM/DD')}
+                  className={`flex h-124 w-92 items-start justify-center p-12 font-medium ${
                     isOtherMonth ? 'text-gray-300' : 'text-gray-800'
                   }`}
                 >

--- a/packages/design-system/src/components/calendar/CalendarHeader.tsx
+++ b/packages/design-system/src/components/calendar/CalendarHeader.tsx
@@ -1,0 +1,25 @@
+import type { Dayjs } from 'dayjs';
+
+interface CurrentHeaderProps {
+  currentMonth: Dayjs;
+  onPrev: () => void;
+  onNext: () => void;
+}
+
+// CalendarHeader 컴포넌트
+// 해당 월 표기, 전월, 다음월 이동 버튼
+export default function CalendarHeader({ currentMonth, onPrev, onNext }: CurrentHeaderProps) {
+  return (
+    <div className='flex w-640 flex-row justify-center gap-30 py-6 text-xl font-bold'>
+      {/* ◀︎ 아이콘으로 수정 예정 */}
+      <button className='cursor-pointer' onClick={onPrev}>
+        ◀︎
+      </button>
+      <div>{currentMonth.format('YYYY년 MM월')}</div>
+      {/* ▶︎ 아이콘으로 수정 예정 */}
+      <button className='cursor-pointer' onClick={onNext}>
+        ▶︎
+      </button>
+    </div>
+  );
+}

--- a/packages/design-system/src/components/calendar/CalendarHeader.tsx
+++ b/packages/design-system/src/components/calendar/CalendarHeader.tsx
@@ -39,12 +39,12 @@ interface CurrentHeaderProps {
  */
 export default function CalendarHeader({ currentMonth, onPrev, onNext }: CurrentHeaderProps) {
   return (
-    <div className='flex justify-center gap-30 py-6'>
+    <div className='flex w-full justify-center gap-30 py-6'>
       {/* ◀︎ 아이콘으로 수정 예정, 버튼 공통컴포넌트로 수정 예정 */}
       <button className='cursor-pointer' onClick={onPrev}>
         ◀︎
       </button>
-      <div className='text-xl font-bold text-[#1b1b1b]'>{currentMonth.format('YYYY년 MM월')}</div>
+      <div className='text-lg font-bold text-[#1b1b1b] md:text-xl'>{currentMonth.format('YYYY년 MM월')}</div>
       {/* ▶︎ 아이콘으로 수정 예정, 버튼 공통컴포넌트로 수정 예정 */}
       <button className='cursor-pointer' onClick={onNext}>
         ▶︎

--- a/packages/design-system/src/components/calendar/CalendarHeader.tsx
+++ b/packages/design-system/src/components/calendar/CalendarHeader.tsx
@@ -1,22 +1,51 @@
 import type { Dayjs } from 'dayjs';
 
 interface CurrentHeaderProps {
+  /**
+   * 현재 표시 중인 월 (Dayjs 객체)
+   */
   currentMonth: Dayjs;
+
+  /**
+   * 이전 달로 이동할 때 호출되는 콜백 함수
+   */
   onPrev: () => void;
+
+  /**
+   * 다음 달로 이동할 때 호출되는 콜백 함수
+   */
   onNext: () => void;
 }
 
-// CalendarHeader 컴포넌트
-// 해당 월 표기, 전월, 다음월 이동 버튼
+/**
+ * CalendarHeader 컴포넌트
+ *
+ * - 현재 월을 텍스트로 표시하고,
+ * - 이전/다음 월로 이동할 수 있는 버튼을 제공합니다.
+ * - 월 이동 시 상위 컴포넌트로부터 전달된 핸들러(`onPrev`, `onNext`)를 호출합니다.
+ *
+ * @component
+ * @param {CurrentHeaderProps} props
+ * @returns {JSX.Element}
+ *
+ * @example
+ * ```tsx
+ * <CalendarHeader
+ *   currentMonth={dayjs()}
+ *   onPrev={() => setMonth((prev) => prev.subtract(1, 'month'))}
+ *   onNext={() => setMonth((prev) => prev.add(1, 'month'))}
+ * />
+ * ```
+ */
 export default function CalendarHeader({ currentMonth, onPrev, onNext }: CurrentHeaderProps) {
   return (
-    <div className='flex w-640 flex-row justify-center gap-30 py-6 text-xl font-bold'>
-      {/* ◀︎ 아이콘으로 수정 예정 */}
+    <div className='flex justify-center gap-30 py-6'>
+      {/* ◀︎ 아이콘으로 수정 예정, 버튼 공통컴포넌트로 수정 예정 */}
       <button className='cursor-pointer' onClick={onPrev}>
         ◀︎
       </button>
-      <div>{currentMonth.format('YYYY년 MM월')}</div>
-      {/* ▶︎ 아이콘으로 수정 예정 */}
+      <div className='text-xl font-bold text-[#1b1b1b]'>{currentMonth.format('YYYY년 MM월')}</div>
+      {/* ▶︎ 아이콘으로 수정 예정, 버튼 공통컴포넌트로 수정 예정 */}
       <button className='cursor-pointer' onClick={onNext}>
         ▶︎
       </button>

--- a/packages/design-system/src/components/calendar/index.ts
+++ b/packages/design-system/src/components/calendar/index.ts
@@ -1,0 +1,3 @@
+export { default as Calendar } from '@/components/calendar/Calendar';
+export { default as CalendarGrid } from '@/components/calendar/CalendarGrid';
+export { default as CalendarHeader } from '@/components/calendar/CalendarHeader';

--- a/packages/design-system/src/components/index.ts
+++ b/packages/design-system/src/components/index.ts
@@ -1,1 +1,2 @@
 export { default as Button } from './Button';
+export * from '@/components/calendar/index';

--- a/packages/design-system/src/layouts/Sidebar.tsx
+++ b/packages/design-system/src/layouts/Sidebar.tsx
@@ -12,6 +12,7 @@ export default function DesignSystemLayout() {
           <ul className='m-0 list-none p-0'>
             <SidebarNavItem label='Button (Example Doc)' to='/docs/button-example' />
             {/* ✅ 아래에 <SidebarNavItem>을 활용한 컴포넌트 문서 링크를 추가해주세요. */}
+            <SidebarNavItem label='Calendar' to='/docs/Calendar' />
           </ul>
         </nav>
       </aside>

--- a/packages/design-system/src/pages/CalendarDoc.tsx
+++ b/packages/design-system/src/pages/CalendarDoc.tsx
@@ -1,0 +1,37 @@
+import Playground from '@/layouts/Playground';
+
+import Calendar from '../components/calendar/Calendar';
+import DocTemplate, { DocCode } from '../layouts/DocTemplate';
+
+/* Playground는 편집 가능한 코드 블록입니다. */
+/* Playground에서 사용할 예시 코드를 작성해주세요. */
+const code = `예시 코드를 작성해주세요.`;
+
+export default function CalendarDoc() {
+  return (
+    <>
+      <DocTemplate
+        description={`
+# Calendar 컴포넌트
+
+간단한 설명을 작성해주세요.
+`}
+        propsDescription={`
+| 이름 | 타입 | 설명 |
+|------|------|------|
+| example | string | 예시 prop입니다. |
+`}
+        title='Calendar'
+      />
+      {/* 실제 컴포넌트를 아래에 작성해주세요 */}
+      {/* 예시 코드 */}
+      <DocCode code={`<Calendar variant="primary">Click me</Calendar>`} />
+
+      {/* Playground는 편집 가능한 코드 블록입니다. */}
+      <div className='mt-24'>
+        <Playground code={code} scope={{ Calendar }} />
+      </div>
+      <Calendar />
+    </>
+  );
+}

--- a/packages/design-system/src/pages/CalendarDoc.tsx
+++ b/packages/design-system/src/pages/CalendarDoc.tsx
@@ -5,33 +5,41 @@ import DocTemplate, { DocCode } from '../layouts/DocTemplate';
 
 /* Playground는 편집 가능한 코드 블록입니다. */
 /* Playground에서 사용할 예시 코드를 작성해주세요. */
-const code = `예시 코드를 작성해주세요.`;
+const code = `<Calendar />`;
 
 export default function CalendarDoc() {
   return (
     <>
       <DocTemplate
         description={`
-# Calendar 컴포넌트
+현재 월을 기준으로 월간 캘린더를 렌더링하는 UI 컴포넌트입니다.  
+날짜 그리드, 월 이동 버튼 등을 포함하며, 추후 예약이나 일정 관련 기능을 확장할 예정입니다.
 
-간단한 설명을 작성해주세요.
+아래는 기본적인 사용 예시입니다:
+
+\`\`\`tsx
+import { Calendar } from '@what-today/design-system';
+
+<Calendar />
+\`\`\`
 `}
         propsDescription={`
-| 이름 | 타입 | 설명 |
-|------|------|------|
-| example | string | 예시 prop입니다. |
+| 이름         | 타입           | 설명                                      |
+|--------------|----------------|-------------------------------------------|
+| currentMonth | \`Dayjs\`      | 현재 렌더링할 달의 날짜 객체입니다.       |
+| onPrev       | \`() => void\` | 이전 달로 이동할 때 호출되는 콜백입니다. |
+| onNext       | \`() => void\` | 다음 달로 이동할 때 호출되는 콜백입니다. |
 `}
         title='Calendar'
       />
       {/* 실제 컴포넌트를 아래에 작성해주세요 */}
       {/* 예시 코드 */}
-      <DocCode code={`<Calendar variant="primary">Click me</Calendar>`} />
+      <DocCode code='<Calendar />' />
 
       {/* Playground는 편집 가능한 코드 블록입니다. */}
       <div className='mt-24'>
         <Playground code={code} scope={{ Calendar }} />
       </div>
-      <Calendar />
     </>
   );
 }

--- a/packages/design-system/src/routes/index.tsx
+++ b/packages/design-system/src/routes/index.tsx
@@ -1,5 +1,6 @@
 import Sidebar from '@layouts/Sidebar';
 import ButtonExampleDocs from '@pages/ButtonExampleDocs';
+import CalendarDoc from '@pages/CalendarDoc';
 import LandingPage from '@pages/LandingPage';
 import { createBrowserRouter, Navigate } from 'react-router-dom';
 
@@ -19,6 +20,10 @@ const router = createBrowserRouter([
       {
         path: 'button-example',
         element: <ButtonExampleDocs />,
+      },
+      {
+        path: 'Calendar',
+        element: <CalendarDoc />,
       },
     ],
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       axios:
         specifier: ^1.10.0
         version: 1.10.0
+      dayjs:
+        specifier: ^1.11.13
+        version: 1.11.13
       motion:
         specifier: ^12.23.0
         version: 12.23.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -1173,6 +1176,9 @@ packages:
   data-view-byte-offset@1.0.1:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
+
+  dayjs@1.11.13:
+    resolution: {integrity: sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==}
 
   debug@4.4.1:
     resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
@@ -4003,6 +4009,8 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-data-view: 1.0.2
+
+  dayjs@1.11.13: {}
 
   debug@4.4.1:
     dependencies:


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- 이슈 번호 #27 

## 📌 작업 내용
<!-- 해당 PR의 변경 사항을 자세하게 적어주세요.-->
- dayjs 라이브러리 설치
- 캘린더 기본 UI 구현, 반응형 적용
- 이전달, 다음달로 이동
- 1일이 포함된 주 ~ 마지막 날짜가 포함된 주를 기준으로 함(4~6주)
- 해당 월이 아닌 날짜는 회색으로 표시

## ✅ 체크리스트

- [x] PR 하기 전에 이슈에서 빼먹은건 없는지 확인했습니다
  - [x] 라벨 및 마일스톤을 사이드 탭에서 등록했습니다.
- [x] PR을 보내는 브랜치가 올바른지 확인했습니다.
- [x] 팀원들이 리뷰하기 쉽도록 설명을 자세하게 작성했습니다.
- [x] 변경사항을 충분히 테스트 했습니다.
- [x] (함수를 구현 했을 때) JSDoc을 양식에 맞춰서 작성했습니다.
- [x] 컨벤션에 맞게 구현했습니다.

## 📷 UI 변경 사항 (선택)
<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->

https://github.com/user-attachments/assets/6e93930f-fa77-4ce2-a2df-cbb535ec2627


- 

## ❓무슨 문제가 발생했나요? (선택)
- 테스트하는 과정에서 모바일일때 375px까지 캘린더 너비가 작아저야 하는데, 일정 너비 이하로 줄어들지 않습니다.. design system 문서 상 다른 컨텐츠 들의 크기도 더 이상 줄어들지 않는 지점인데, 이게 페이지 자체에 설정이 있는걸까요? 캘린더 컴포넌트 반응형에 문제라면 조금 더 고민해보겠습니다..(하루종일 고민했는데 실패해서 진도가 안나갈 것 같아 우선 PR 올립니다!)

https://github.com/user-attachments/assets/b31474fc-ac70-4069-aed1-873d78cbd7e1

## 💬 기타 참고 사항 (선택)
<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->
- 현재는 기능 없이 UI만 그리는 컴포넌트이다보니 design system 문서가 매우 간단한 것 같네요..^^
