### PR TITLE
드롭다운 공통 컴포넌트 구현

### DIFF
--- a/packages/design-system/src/components/dropdown/Dropdown.tsx
+++ b/packages/design-system/src/components/dropdown/Dropdown.tsx
@@ -1,0 +1,38 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { DropdownContext } from '@/components/dropdown/DropdownContext';
+
+interface DropdownProps {
+  children: React.ReactNode;
+}
+
+export default function Dropdown({ children }: DropdownProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  // dropdown 상태 반전
+  const toggle = useCallback(() => {
+    setIsOpen((prev) => !prev);
+  }, []);
+
+  // dropdown 닫기
+  const close = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  // 외부 영역 클릭하면 dropdown 닫기
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        close();
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+  }, [close]);
+
+  return (
+    <DropdownContext.Provider value={{ isOpen, toggle, close }}>
+      <div ref={dropdownRef}>{children}</div>
+    </DropdownContext.Provider>
+  );
+}

--- a/packages/design-system/src/components/dropdown/Dropdown.tsx
+++ b/packages/design-system/src/components/dropdown/Dropdown.tsx
@@ -1,14 +1,32 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useState } from 'react';
 
 import { DropdownContext } from '@/components/dropdown/DropdownContext';
 
 interface DropdownProps {
+  /**
+   * Dropdown 내부에 포함될 자식 요소들 (Trigger, Menu 등)
+   */
   children: React.ReactNode;
 }
 
+/**
+ * Dropdown 컴포넌트
+ *
+ * - 드롭다운 메뉴의 열림/닫힘 상태를 관리하며, 관련 컨텍스트를 하위 트리에 제공합니다.
+ * - `DropdownContext`를 통해 toggle, close 함수와 triggerRef를 공유합니다.
+ *
+ * @component
+ * @example
+ * ```tsx
+ * <Dropdown>
+ *   <DropdownTrigger>메뉴 열기</DropdownTrigger>
+ *   <DropdownMenu>...</DropdownMenu>
+ * </Dropdown>
+ * ```
+ */
 export default function Dropdown({ children }: DropdownProps) {
   const [isOpen, setIsOpen] = useState(false);
-  const dropdownRef = useRef<HTMLDivElement>(null);
+  const [triggerRef, setTriggerRef] = useState<HTMLElement | null>(null);
 
   // dropdown 상태 반전
   const toggle = useCallback(() => {
@@ -20,19 +38,9 @@ export default function Dropdown({ children }: DropdownProps) {
     setIsOpen(false);
   }, []);
 
-  // 외부 영역 클릭하면 dropdown 닫기
-  useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
-      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
-        close();
-      }
-    };
-    document.addEventListener('mousedown', handleClickOutside);
-  }, [close]);
-
   return (
-    <DropdownContext.Provider value={{ isOpen, toggle, close }}>
-      <div ref={dropdownRef}>{children}</div>
+    <DropdownContext.Provider value={{ isOpen, toggle, close, triggerRef, setTriggerRef }}>
+      <div className='relative inline-block'>{children}</div>
     </DropdownContext.Provider>
   );
 }

--- a/packages/design-system/src/components/dropdown/DropdownContext.tsx
+++ b/packages/design-system/src/components/dropdown/DropdownContext.tsx
@@ -1,13 +1,41 @@
 import { createContext, useContext } from 'react';
 
 export interface DropdownContextType {
+  /**
+   * 드롭다운 열림 여부
+   */
   isOpen: boolean;
+  /**
+   * 드롭다운 상태를 반전시키는 함수
+   */
   toggle: () => void;
+  /**
+   * 드롭다운을 닫는 함수
+   */
   close: () => void;
+  /**
+   * 드롭다운을 여는 트리거 요소의 참조
+   */
+  triggerRef?: HTMLElement | null;
+  /**
+   * 트리거 요소의 참조를 설정하는 함수
+   */
+  setTriggerRef: (ref: HTMLElement | null) => void;
 }
 
 export const DropdownContext = createContext<DropdownContextType | null>(null);
 
+/**
+ * DropdownContext에 접근하기 위한 커스텀 훅
+ *
+ * @throws 사용 위치가 `<Dropdown>` 컴포넌트 내부가 아닐 경우 에러를 발생시킴
+ * @returns {DropdownContextType} 드롭다운 상태와 제어 함수
+ *
+ * @example
+ * ```tsx
+ * const { isOpen, toggle } = useDropdownContext();
+ * ```
+ */
 export const useDropdownContext = () => {
   const context = useContext(DropdownContext);
   if (!context) {

--- a/packages/design-system/src/components/dropdown/DropdownContext.tsx
+++ b/packages/design-system/src/components/dropdown/DropdownContext.tsx
@@ -1,0 +1,17 @@
+import { createContext, useContext } from 'react';
+
+export interface DropdownContextType {
+  isOpen: boolean;
+  toggle: () => void;
+  close: () => void;
+}
+
+export const DropdownContext = createContext<DropdownContextType | null>(null);
+
+export const useDropdownContext = () => {
+  const context = useContext(DropdownContext);
+  if (!context) {
+    throw new Error('Dropdown 내부에서만 사용 가능합니다.');
+  }
+  return context;
+};

--- a/packages/design-system/src/components/dropdown/DropdownItem.tsx
+++ b/packages/design-system/src/components/dropdown/DropdownItem.tsx
@@ -16,6 +16,8 @@ export default function DropdownItem({ onClick, ...props }: HTMLAttributes<HTMLD
       className={twMerge('cursor-pointer px-20 py-14 text-center text-lg font-medium text-gray-950', props.className)}
       onClick={handleClick}
       {...props}
-    />
+    >
+      {props.children}
+    </div>
   );
 }

--- a/packages/design-system/src/components/dropdown/DropdownItem.tsx
+++ b/packages/design-system/src/components/dropdown/DropdownItem.tsx
@@ -3,6 +3,24 @@ import { twMerge } from 'tailwind-merge';
 
 import { useDropdownContext } from '@/components/dropdown/DropdownContext';
 
+/**
+ * DropdownItem 컴포넌트
+ *
+ * - 드롭다운 메뉴 내 개별 항목을 표현합니다.
+ * - 클릭 시 사용자 정의 `onClick` 핸들러를 호출한 후 자동으로 드롭다운을 닫습니다.
+ * - `div`의 기본 HTML 속성을 확장하여 스타일, 이벤트 등 자유롭게 지정할 수 있습니다.
+ *
+ * @component
+ * @param {HTMLAttributes<HTMLDivElement>} props - div 요소에 전달할 속성들 (`onClick`, `className`, `children` 등)
+ * @returns {JSX.Element} 드롭다운 메뉴 항목
+ *
+ * @example
+ * ```tsx
+ * <DropdownItem onClick={() => alert('선택됨')}>
+ *   항목 1
+ * </DropdownItem>
+ * ```
+ */
 export default function DropdownItem({ onClick, ...props }: HTMLAttributes<HTMLDivElement>) {
   const { close } = useDropdownContext();
 

--- a/packages/design-system/src/components/dropdown/DropdownItem.tsx
+++ b/packages/design-system/src/components/dropdown/DropdownItem.tsx
@@ -1,7 +1,21 @@
-import type { HTMLAttributes } from 'react';
 import { twMerge } from 'tailwind-merge';
 
 import { useDropdownContext } from '@/components/dropdown/DropdownContext';
+
+interface DropdownItemProps {
+  /**
+   * DropdownItem 스타일 커스텀 가능
+   */
+  className?: string;
+  /**
+   * DropdownItem 내부에 포함될 자식 요소들
+   */
+  children: React.ReactNode;
+  /**
+   * DropdownItem 선택시 실행될 함수
+   */
+  onClick: (e: React.MouseEvent<HTMLDivElement>) => void;
+}
 
 /**
  * DropdownItem 컴포넌트
@@ -11,31 +25,29 @@ import { useDropdownContext } from '@/components/dropdown/DropdownContext';
  * - `div`의 기본 HTML 속성을 확장하여 스타일, 이벤트 등 자유롭게 지정할 수 있습니다.
  *
  * @component
- * @param {HTMLAttributes<HTMLDivElement>} props - div 요소에 전달할 속성들 (`onClick`, `className`, `children` 등)
+ * @param {DropdownItemProps} props - div 요소에 전달할 속성들 (`onClick`, `className`, `children` 등)
  * @returns {JSX.Element} 드롭다운 메뉴 항목
  *
  * @example
  * ```tsx
- * <DropdownItem onClick={() => alert('선택됨')}>
+ * <DropdownItem onClick={(e) => alert('선택됨')}>
  *   항목 1
  * </DropdownItem>
  * ```
  */
-export default function DropdownItem({ onClick, ...props }: HTMLAttributes<HTMLDivElement>) {
+export default function DropdownItem({ className, children, onClick }: DropdownItemProps) {
   const { close } = useDropdownContext();
 
   const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
     onClick?.(e);
     close();
   };
+  const baseClass =
+    'cursor-pointer px-20 py-14 text-center text-lg font-medium text-gray-950 hover:bg-primary-100 first:rounded-t-lg last:rounded-b-lg';
 
   return (
-    <div
-      className={twMerge('cursor-pointer px-20 py-14 text-center text-lg font-medium text-gray-950', props.className)}
-      onClick={handleClick}
-      {...props}
-    >
-      {props.children}
+    <div className={twMerge(baseClass, className)} onClick={handleClick}>
+      {children}
     </div>
   );
 }

--- a/packages/design-system/src/components/dropdown/DropdownItem.tsx
+++ b/packages/design-system/src/components/dropdown/DropdownItem.tsx
@@ -1,0 +1,21 @@
+import type { HTMLAttributes } from 'react';
+import { twMerge } from 'tailwind-merge';
+
+import { useDropdownContext } from '@/components/dropdown/DropdownContext';
+
+export default function DropdownItem({ onClick, ...props }: HTMLAttributes<HTMLDivElement>) {
+  const { close } = useDropdownContext();
+
+  const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    onClick?.(e);
+    close();
+  };
+
+  return (
+    <div
+      className={twMerge('cursor-pointer px-20 py-14 text-center text-lg font-medium text-gray-950', props.className)}
+      onClick={handleClick}
+      {...props}
+    />
+  );
+}

--- a/packages/design-system/src/components/dropdown/DropdownMenu.tsx
+++ b/packages/design-system/src/components/dropdown/DropdownMenu.tsx
@@ -1,0 +1,11 @@
+import type { HTMLAttributes } from 'react';
+import { twMerge } from 'tailwind-merge';
+
+import { useDropdownContext } from '@/components/dropdown/DropdownContext';
+
+export default function DropdownMenu({ ...props }: HTMLAttributes<HTMLDivElement>) {
+  const { isOpen } = useDropdownContext();
+  return isOpen ? (
+    <div className={twMerge('h-110 w-95 rounded-lg border border-gray-100', props.className)} {...props} />
+  ) : null;
+}

--- a/packages/design-system/src/components/dropdown/DropdownMenu.tsx
+++ b/packages/design-system/src/components/dropdown/DropdownMenu.tsx
@@ -1,7 +1,18 @@
-import { type HTMLAttributes, useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { twMerge } from 'tailwind-merge';
 
 import { useDropdownContext } from '@/components/dropdown/DropdownContext';
+
+interface DropdownMenuProps {
+  /**
+   * DropdownMenu 스타일 커스텀 가능
+   */
+  className?: string;
+  /**
+   * DropdownMenu 내부에 포함될 자식 요소들
+   */
+  children: React.ReactNode;
+}
 
 /**
  * DropdownMenu 컴포넌트
@@ -12,7 +23,7 @@ import { useDropdownContext } from '@/components/dropdown/DropdownContext';
  * - 기본 위치는 `absolute top-10 right-10`이며, `className`으로 위치나 스타일을 조정할 수 있습니다.
  *
  * @component
- * @param {HTMLAttributes<HTMLDivElement>} props - div에 전달할 HTML 속성들, `className`을 통해 스타일 커스터마이징 가능.
+ * @param {DropdownMenuProps} props
  * @returns {JSX.Element | null} 드롭다운이 열릴 경우 메뉴를 렌더링, 아니면 null 반환
  *
  * @example
@@ -23,9 +34,10 @@ import { useDropdownContext } from '@/components/dropdown/DropdownContext';
  * </DropdownMenu>
  * ```
  */
-export default function DropdownMenu({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+export default function DropdownMenu({ className, children }: DropdownMenuProps) {
   const { isOpen, close } = useDropdownContext();
   const menuRef = useRef<HTMLDivElement>(null);
+
   // 외부 영역 클릭하면 dropdown 닫기
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
@@ -36,11 +48,11 @@ export default function DropdownMenu({ className, ...props }: HTMLAttributes<HTM
     document.addEventListener('mousedown', handleClickOutside);
   }, [close]);
 
+  const baseClass = 'absolute top-10 right-10 w-95 rounded-lg border border-gray-100 bg-white';
+
   return isOpen ? (
-    <div
-      ref={menuRef}
-      className={twMerge('absolute top-10 right-10 h-110 w-95 rounded-lg border border-gray-100 bg-white', className)}
-      {...props}
-    />
+    <div ref={menuRef} className={twMerge(baseClass, className)}>
+      {children}
+    </div>
   ) : null;
 }

--- a/packages/design-system/src/components/dropdown/DropdownMenu.tsx
+++ b/packages/design-system/src/components/dropdown/DropdownMenu.tsx
@@ -3,7 +3,7 @@ import { twMerge } from 'tailwind-merge';
 
 import { useDropdownContext } from '@/components/dropdown/DropdownContext';
 
-export default function DropdownMenu({ ...props }: HTMLAttributes<HTMLDivElement>) {
+export default function DropdownMenu(props: HTMLAttributes<HTMLDivElement>) {
   const { isOpen } = useDropdownContext();
   return isOpen ? (
     <div className={twMerge('h-110 w-95 rounded-lg border border-gray-100', props.className)} {...props} />

--- a/packages/design-system/src/components/dropdown/DropdownMenu.tsx
+++ b/packages/design-system/src/components/dropdown/DropdownMenu.tsx
@@ -1,11 +1,46 @@
-import type { HTMLAttributes } from 'react';
+import { type HTMLAttributes, useEffect, useRef } from 'react';
 import { twMerge } from 'tailwind-merge';
 
 import { useDropdownContext } from '@/components/dropdown/DropdownContext';
 
-export default function DropdownMenu(props: HTMLAttributes<HTMLDivElement>) {
-  const { isOpen } = useDropdownContext();
+/**
+ * DropdownMenu 컴포넌트
+ *
+ * 드롭다운 메뉴를 렌더링합니다.
+ * - 드롭다운이 열려 있을 때(`isOpen`이 `true`)에만 메뉴를 보여줍니다.
+ * - 외부 영역을 클릭하면 자동으로 닫히는 기능을 내장하고 있습니다.
+ * - 기본 위치는 `absolute top-10 right-10`이며, `className`으로 위치나 스타일을 조정할 수 있습니다.
+ *
+ * @component
+ * @param {HTMLAttributes<HTMLDivElement>} props - div에 전달할 HTML 속성들, `className`을 통해 스타일 커스터마이징 가능.
+ * @returns {JSX.Element | null} 드롭다운이 열릴 경우 메뉴를 렌더링, 아니면 null 반환
+ *
+ * @example
+ * ```tsx
+ * <DropdownMenu className="p-4 shadow-lg">
+ *   <p>옵션 1</p>
+ *   <p>옵션 2</p>
+ * </DropdownMenu>
+ * ```
+ */
+export default function DropdownMenu({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  const { isOpen, close } = useDropdownContext();
+  const menuRef = useRef<HTMLDivElement>(null);
+  // 외부 영역 클릭하면 dropdown 닫기
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        close();
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+  }, [close]);
+
   return isOpen ? (
-    <div className={twMerge('h-110 w-95 rounded-lg border border-gray-100', props.className)} {...props} />
+    <div
+      ref={menuRef}
+      className={twMerge('absolute top-10 right-10 h-110 w-95 rounded-lg border border-gray-100 bg-white', className)}
+      {...props}
+    />
   ) : null;
 }

--- a/packages/design-system/src/components/dropdown/DropdownTrigger.tsx
+++ b/packages/design-system/src/components/dropdown/DropdownTrigger.tsx
@@ -1,7 +1,18 @@
-import { type ButtonHTMLAttributes, useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { twMerge } from 'tailwind-merge';
 
 import { useDropdownContext } from '@/components/dropdown/DropdownContext';
+
+interface DropdownTriggerProps {
+  /**
+   * DropdownTrigger 스타일 커스텀 가능
+   */
+  className?: string;
+  /**
+   * DropdownTrigger 내부에 포함될 자식 요소들
+   */
+  children?: React.ReactNode;
+}
 
 /**
  * DropdownTrigger 컴포넌트
@@ -9,10 +20,10 @@ import { useDropdownContext } from '@/components/dropdown/DropdownContext';
  * - 드롭다운을 여닫는 트리거 역할의 버튼입니다.
  * - 클릭 시 `toggle()` 함수를 호출하여 드롭다운을 열거나 닫습니다.
  * - 버튼 요소의 ref를 `DropdownContext`에 등록해 외부 클릭 감지 등에 사용합니다.
- * - 기본 버튼 속성을 확장하여 자유롭게 커스터마이징 가능합니다.
+ * - 기본 스타일에 추가로 `className`으로 커스터마이징 가능합니다.
  *
  * @component
- * @param {ButtonHTMLAttributes<HTMLButtonElement>} props - 버튼에 전달할 HTML 속성들
+ * @param {DropdownTriggerProps} props - 스타일과 자식 요소 포함
  * @returns {JSX.Element} 드롭다운 토글 버튼
  *
  * @example
@@ -22,7 +33,7 @@ import { useDropdownContext } from '@/components/dropdown/DropdownContext';
  * </DropdownTrigger>
  * ```
  */
-export default function DropdownTrigger(props: ButtonHTMLAttributes<HTMLButtonElement>) {
+export default function DropdownTrigger({ className, children }: DropdownTriggerProps) {
   const { toggle, setTriggerRef } = useDropdownContext();
   const triggerRef = useRef<HTMLButtonElement | null>(null);
 
@@ -33,14 +44,9 @@ export default function DropdownTrigger(props: ButtonHTMLAttributes<HTMLButtonEl
   }, [setTriggerRef]);
 
   return (
-    <button
-      ref={triggerRef}
-      className={twMerge('cursor-pointer text-2xl', props.className)}
-      type='button'
-      onClick={toggle}
-      {...props}
-    >
-      {props.children || ':'}
+    <button ref={triggerRef} className={twMerge('cursor-pointer text-2xl', className)} type='button' onClick={toggle}>
+      {/* 아이콘으로 수정 예정 */}
+      {children || ':'}
     </button>
   );
 }

--- a/packages/design-system/src/components/dropdown/DropdownTrigger.tsx
+++ b/packages/design-system/src/components/dropdown/DropdownTrigger.tsx
@@ -1,0 +1,13 @@
+import type { ButtonHTMLAttributes } from 'react';
+import { twMerge } from 'tailwind-merge';
+
+import { useDropdownContext } from '@/components/dropdown/DropdownContext';
+
+export default function DropdownTrigger(props: ButtonHTMLAttributes<HTMLButtonElement>) {
+  const { toggle } = useDropdownContext();
+  return (
+    <button className={twMerge('cursor-pointer text-2xl', props.className)} type='button' onClick={toggle} {...props}>
+      :
+    </button>
+  );
+}

--- a/packages/design-system/src/components/dropdown/DropdownTrigger.tsx
+++ b/packages/design-system/src/components/dropdown/DropdownTrigger.tsx
@@ -1,13 +1,46 @@
-import type { ButtonHTMLAttributes } from 'react';
+import { type ButtonHTMLAttributes, useEffect, useRef } from 'react';
 import { twMerge } from 'tailwind-merge';
 
 import { useDropdownContext } from '@/components/dropdown/DropdownContext';
 
+/**
+ * DropdownTrigger 컴포넌트
+ *
+ * - 드롭다운을 여닫는 트리거 역할의 버튼입니다.
+ * - 클릭 시 `toggle()` 함수를 호출하여 드롭다운을 열거나 닫습니다.
+ * - 버튼 요소의 ref를 `DropdownContext`에 등록해 외부 클릭 감지 등에 사용합니다.
+ * - 기본 버튼 속성을 확장하여 자유롭게 커스터마이징 가능합니다.
+ *
+ * @component
+ * @param {ButtonHTMLAttributes<HTMLButtonElement>} props - 버튼에 전달할 HTML 속성들
+ * @returns {JSX.Element} 드롭다운 토글 버튼
+ *
+ * @example
+ * ```tsx
+ * <DropdownTrigger className="px-4 py-2 bg-blue-500 text-white">
+ *   메뉴 열기
+ * </DropdownTrigger>
+ * ```
+ */
 export default function DropdownTrigger(props: ButtonHTMLAttributes<HTMLButtonElement>) {
-  const { toggle } = useDropdownContext();
+  const { toggle, setTriggerRef } = useDropdownContext();
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    if (triggerRef.current) {
+      setTriggerRef(triggerRef.current);
+    }
+  }, [setTriggerRef]);
+
   return (
-    <button className={twMerge('cursor-pointer text-2xl', props.className)} type='button' onClick={toggle} {...props}>
-      :
+    <button
+      ref={triggerRef}
+      className={twMerge('cursor-pointer text-2xl', props.className)}
+      type='button'
+      onClick={toggle}
+      {...props}
+    >
+      {props.children || ':'}
     </button>
   );
 }

--- a/packages/design-system/src/components/dropdown/index.ts
+++ b/packages/design-system/src/components/dropdown/index.ts
@@ -1,0 +1,4 @@
+export { default as Dropdown } from '@/components/dropdown/Dropdown';
+export { default as DropdownItem } from '@/components/dropdown/DropdownItem';
+export { default as DropdownMenu } from '@/components/dropdown/DropdownMenu';
+export { default as DropdownTrigger } from '@/components/dropdown/DropdownTrigger';

--- a/packages/design-system/src/components/index.ts
+++ b/packages/design-system/src/components/index.ts
@@ -1,2 +1,3 @@
 export { default as Button } from './Button';
 export { default as Pagination } from './Pagination';
+export * from '@/components/dropdown/index';

--- a/packages/design-system/src/layouts/Sidebar.tsx
+++ b/packages/design-system/src/layouts/Sidebar.tsx
@@ -13,6 +13,7 @@ export default function DesignSystemLayout() {
             <SidebarNavItem label='Button (Example Doc)' to='/docs/button-example' />
             {/* ✅ 아래에 <SidebarNavItem>을 활용한 컴포넌트 문서 링크를 추가해주세요. */}
             <SidebarNavItem label='Pagination' to='/docs/Pagination' />
+            <SidebarNavItem label='Dropdown' to='/docs/Dropdown' />
           </ul>
         </nav>
       </aside>

--- a/packages/design-system/src/pages/DropdownDoc.tsx
+++ b/packages/design-system/src/pages/DropdownDoc.tsx
@@ -1,34 +1,78 @@
 import Dropdown from '@/components/dropdown/Dropdown';
+import DropdownItem from '@/components/dropdown/DropdownItem';
+import DropdownMenu from '@/components/dropdown/DropdownMenu';
+import DropdownTrigger from '@/components/dropdown/DropdownTrigger';
 import DocTemplate, { DocCode } from '@/layouts/DocTemplate';
 import Playground from '@/layouts/Playground';
 
 /* Playground는 편집 가능한 코드 블록입니다. */
 /* Playground에서 사용할 예시 코드를 작성해주세요. */
-const code = `예시 코드를 작성해주세요.`;
+const code = `<Dropdown>
+        <DropdownTrigger />
+        <DropdownMenu>
+          <DropdownItem onClick={() => alert('수정하기')}>수정하기</DropdownItem>
+          <DropdownItem onClick={() => alert('삭제하기')}>삭제하기</DropdownItem>
+        </DropdownMenu>
+      </Dropdown>`;
 
 export default function DropdownDoc() {
   return (
     <>
       <DocTemplate
         description={`
-# Dropdown 컴포넌트
+Dropdown은 버튼을 클릭했을 때 메뉴 리스트를 표시하는 컴포넌트입니다.  
+합성 컴포넌트 패턴으로 구성되어 있어 선언적으로 사용하며 각 역할을 명확히 나눌 수 있습니다.
 
-간단한 설명을 작성해주세요.
+- Dropdown: 상태를 관리하고 Context를 제공하는 최상위 컴포넌트입니다.
+- DropdownTrigger: 드롭다운을 열고 닫는 버튼 역할입니다.
+- DropdownMenu: 드롭다운이 열렸을 때 표시되는 영역입니다.
+- DropdownItem: 실제 메뉴 항목입니다. 클릭 시 드롭다운을 자동으로 닫을 수 있습니다.
 `}
         propsDescription={`
+### Dropdown
+
 | 이름 | 타입 | 설명 |
 |------|------|------|
-| example | string | 예시 prop입니다. |
+| children | React.ReactNode | 드롭다운 하위 요소들을 포함합니다. |
+
+### DropdownTrigger (button 확장)
+
+| 이름 | 타입 | 설명 |
+|------|------|------|
+| ...props | ButtonHTMLAttributes | HTML button 요소에 전달되는 모든 속성을 지원합니다. |
+
+### DropdownMenu (div 확장)
+
+| 이름 | 타입 | 설명 |
+|------|------|------|
+| ...props | HTMLAttributes | HTML div 요소에 전달되는 모든 속성을 지원합니다. |
+
+### DropdownItem (div 확장)
+
+| 이름 | 타입 | 설명 |
+|------|------|------|
+| onClick | (e: MouseEvent) => void | 클릭 시 실행할 동작입니다. 클릭 후 드롭다운은 자동으로 닫힙니다. |
+| ...props | HTMLAttributes | HTML div 요소에 전달되는 모든 속성을 지원합니다. |
 `}
         title='Dropdown'
       />
       {/* 실제 컴포넌트를 아래에 작성해주세요 */}
       {/* 예시 코드 */}
-      <DocCode code={`<Dropdown variant="primary">Click me</Dropdown>`} />
+      <DocCode
+        code={`<Dropdown>
+  <DropdownTrigger className="bg-blue-500 text-white px-4 py-2 rounded">
+    메뉴 열기
+  </DropdownTrigger>
+  <DropdownMenu className="mt-2 w-40 bg-white rounded shadow">
+    <DropdownItem onClick={() => alert('수정하기')}>수정하기</DropdownItem>
+    <DropdownItem onClick={() => alert('삭제하기')}>삭제하기</DropdownItem>
+  </DropdownMenu>
+</Dropdown>`}
+      />
 
       {/* Playground는 편집 가능한 코드 블록입니다. */}
       <div className='mt-24'>
-        <Playground code={code} scope={{ Dropdown }} />
+        <Playground code={code} scope={{ Dropdown, DropdownTrigger, DropdownMenu, DropdownItem }} />
       </div>
     </>
   );

--- a/packages/design-system/src/pages/DropdownDoc.tsx
+++ b/packages/design-system/src/pages/DropdownDoc.tsx
@@ -1,19 +1,5 @@
-import Dropdown from '@/components/dropdown/Dropdown';
-import DropdownItem from '@/components/dropdown/DropdownItem';
-import DropdownMenu from '@/components/dropdown/DropdownMenu';
-import DropdownTrigger from '@/components/dropdown/DropdownTrigger';
+import { Dropdown, DropdownItem, DropdownMenu, DropdownTrigger } from '@/components';
 import DocTemplate, { DocCode } from '@/layouts/DocTemplate';
-import Playground from '@/layouts/Playground';
-
-/* Playground는 편집 가능한 코드 블록입니다. */
-/* Playground에서 사용할 예시 코드를 작성해주세요. */
-const code = `<Dropdown>
-        <DropdownTrigger />
-        <DropdownMenu>
-          <DropdownItem onClick={() => alert('수정하기')}>수정하기</DropdownItem>
-          <DropdownItem onClick={() => alert('삭제하기')}>삭제하기</DropdownItem>
-        </DropdownMenu>
-      </Dropdown>`;
 
 export default function DropdownDoc() {
   return (
@@ -27,6 +13,20 @@ Dropdown은 버튼을 클릭했을 때 메뉴 리스트를 표시하는 컴포�
 - DropdownTrigger: 드롭다운을 열고 닫는 버튼 역할입니다.
 - DropdownMenu: 드롭다운이 열렸을 때 표시되는 영역입니다.
 - DropdownItem: 실제 메뉴 항목입니다. 클릭 시 드롭다운을 자동으로 닫을 수 있습니다.
+
+아래는 기본적인 사용 예시입니다:
+
+\`\`\`tsx
+import { Dropdown, DropdownItem, DropdownMenu, DropdownTrigger } from '@what-today/design-system';
+
+<Dropdown>
+  <DropdownTrigger />
+  <DropdownMenu className="">
+    <DropdownItem onClick={() => alert('수정')}>수정하기</DropdownItem>
+    <DropdownItem onClick={() => alert('삭제')}>삭제하기</DropdownItem>
+  </DropdownMenu>
+</Dropdown>
+\`\`\`
 `}
         propsDescription={`
 ### Dropdown
@@ -35,44 +35,73 @@ Dropdown은 버튼을 클릭했을 때 메뉴 리스트를 표시하는 컴포�
 |------|------|------|
 | children | React.ReactNode | 드롭다운 하위 요소들을 포함합니다. |
 
-### DropdownTrigger (button 확장)
+### DropdownTrigger
 
 | 이름 | 타입 | 설명 |
 |------|------|------|
-| ...props | ButtonHTMLAttributes | HTML button 요소에 전달되는 모든 속성을 지원합니다. |
+| children? | React.ReactNode | 버튼 내부에 표시할 내용입니다. |
+| className? | string | 버튼에 적용할 CSS 클래스명입니다. |
 
-### DropdownMenu (div 확장)
-
-| 이름 | 타입 | 설명 |
-|------|------|------|
-| ...props | HTMLAttributes | HTML div 요소에 전달되는 모든 속성을 지원합니다. |
-
-### DropdownItem (div 확장)
+### DropdownMenu
 
 | 이름 | 타입 | 설명 |
 |------|------|------|
-| onClick | (e: MouseEvent) => void | 클릭 시 실행할 동작입니다. 클릭 후 드롭다운은 자동으로 닫힙니다. |
-| ...props | HTMLAttributes | HTML div 요소에 전달되는 모든 속성을 지원합니다. |
+| className? | string | 메뉴에 적용할 CSS 클래스명입니다. |
+| children | React.ReactNode | 메뉴 내부에 표시할 내용입니다. |
+
+### DropdownItem
+
+| 이름 | 타입 | 설명 |
+|------|------|------|
+| className? | string | 메뉴 항목에 적용할 CSS 클래스명입니다. |
+| children | React.ReactNode | 메뉴 항목에 표시할 내용입니다. |
+| onClick | (e: MouseEvent) => void | 클릭 시 실행할 함수입니다. 실행 후 드롭다운은 자동으로 닫힙니다. |
 `}
         title='Dropdown'
       />
-      {/* 실제 컴포넌트를 아래에 작성해주세요 */}
-      {/* 예시 코드 */}
+      <h2 className='text-2xl'>기본 드롭다운</h2>
       <DocCode
         code={`<Dropdown>
-  <DropdownTrigger className="bg-blue-500 text-white px-4 py-2 rounded">
-    메뉴 열기
-  </DropdownTrigger>
-  <DropdownMenu className="mt-2 w-40 bg-white rounded shadow">
+  <DropdownTrigger />
+  <DropdownMenu>
     <DropdownItem onClick={() => alert('수정하기')}>수정하기</DropdownItem>
     <DropdownItem onClick={() => alert('삭제하기')}>삭제하기</DropdownItem>
   </DropdownMenu>
 </Dropdown>`}
       />
-
-      {/* Playground는 편집 가능한 코드 블록입니다. */}
-      <div className='mt-24'>
-        <Playground code={code} scope={{ Dropdown, DropdownTrigger, DropdownMenu, DropdownItem }} />
+      <div className='h-200 pl-100'>
+        <Dropdown>
+          <DropdownTrigger />
+          <DropdownMenu>
+            <DropdownItem onClick={() => alert('수정하기')}>수정하기</DropdownItem>
+            <DropdownItem onClick={() => alert('삭제하기')}>삭제하기</DropdownItem>
+          </DropdownMenu>
+        </Dropdown>
+      </div>
+      <h2 className='text-2xl'>커스텀 드롭다운</h2>
+      <DocCode
+        code={`<Dropdown>
+  <DropdownTrigger className='rounded-full border p-4 text-sm'>버튼</DropdownTrigger>
+  <DropdownMenu className='top-full -left-30 mt-4'>
+    <DropdownItem onClick={() => alert('등록하기')}>등록하기</DropdownItem>
+    <DropdownItem className='hover:bg-red-200' onClick={() => alert('수정하기')}>
+      수정하기
+    </DropdownItem>
+    <DropdownItem onClick={() => alert('삭제하기')}>삭제하기</DropdownItem>
+  </DropdownMenu>
+</Dropdown>`}
+      />
+      <div className='h-200 pl-100'>
+        <Dropdown>
+          <DropdownTrigger className='rounded-full border p-4 text-sm'>버튼</DropdownTrigger>
+          <DropdownMenu className='top-full -left-30 mt-4'>
+            <DropdownItem onClick={() => alert('등록하기')}>등록하기</DropdownItem>
+            <DropdownItem className='hover:bg-red-200' onClick={() => alert('수정하기')}>
+              수정하기
+            </DropdownItem>
+            <DropdownItem onClick={() => alert('삭제하기')}>삭제하기</DropdownItem>
+          </DropdownMenu>
+        </Dropdown>
       </div>
     </>
   );

--- a/packages/design-system/src/pages/DropdownDoc.tsx
+++ b/packages/design-system/src/pages/DropdownDoc.tsx
@@ -1,0 +1,35 @@
+import Dropdown from '@/components/dropdown/Dropdown';
+import DocTemplate, { DocCode } from '@/layouts/DocTemplate';
+import Playground from '@/layouts/Playground';
+
+/* Playground는 편집 가능한 코드 블록입니다. */
+/* Playground에서 사용할 예시 코드를 작성해주세요. */
+const code = `예시 코드를 작성해주세요.`;
+
+export default function DropdownDoc() {
+  return (
+    <>
+      <DocTemplate
+        description={`
+# Dropdown 컴포넌트
+
+간단한 설명을 작성해주세요.
+`}
+        propsDescription={`
+| 이름 | 타입 | 설명 |
+|------|------|------|
+| example | string | 예시 prop입니다. |
+`}
+        title='Dropdown'
+      />
+      {/* 실제 컴포넌트를 아래에 작성해주세요 */}
+      {/* 예시 코드 */}
+      <DocCode code={`<Dropdown variant="primary">Click me</Dropdown>`} />
+
+      {/* Playground는 편집 가능한 코드 블록입니다. */}
+      <div className='mt-24'>
+        <Playground code={code} scope={{ Dropdown }} />
+      </div>
+    </>
+  );
+}

--- a/packages/design-system/src/routes/index.tsx
+++ b/packages/design-system/src/routes/index.tsx
@@ -1,5 +1,6 @@
 import Sidebar from '@layouts/Sidebar';
 import ButtonExampleDocs from '@pages/ButtonExampleDocs';
+import DropdownDoc from '@pages/DropdownDoc';
 import LandingPage from '@pages/LandingPage';
 import PaginationDoc from '@pages/PaginationDoc';
 import { createBrowserRouter, Navigate } from 'react-router-dom';
@@ -20,6 +21,10 @@ const router = createBrowserRouter([
       {
         path: 'button-example',
         element: <ButtonExampleDocs />,
+      },
+      {
+        path: 'Dropdown',
+        element: <DropdownDoc />,
       },
       {
         path: 'Pagination',


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- 이슈 번호 #28 

## 📌 작업 내용
<!-- 해당 PR의 변경 사항을 자세하게 적어주세요.-->
- 합성컴포넌트로 구성
- 기본 드롭다운 UI, 위치 지정 (className으로 커스텀 가능)
- 외부 영역 클릭 시 닫힘

## ✅ 체크리스트

- [x] PR 하기 전에 이슈에서 빼먹은건 없는지 확인했습니다
  - [x] 라벨 및 마일스톤을 사이드 탭에서 등록했습니다.
- [x] PR을 보내는 브랜치가 올바른지 확인했습니다.
- [x] 팀원들이 리뷰하기 쉽도록 설명을 자세하게 작성했습니다.
- [x] 변경사항을 충분히 테스트 했습니다.
- [x] (함수를 구현 했을 때) JSDoc을 양식에 맞춰서 작성했습니다.
- [x] 컨벤션에 맞게 구현했습니다.

## 📷 UI 변경 사항 (선택)
<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->

https://github.com/user-attachments/assets/ba0098fd-72f8-45a8-8fc6-1d718d08e6a2


## ❓무슨 문제가 발생했나요? (선택)
<img width="1481" height="827" alt="image" src="https://github.com/user-attachments/assets/716dab63-e102-49ee-8853-5aa585cebecd" />
각 컴포넌트별로 props를 작성하였는데 이름, 타입, 설명 칸이 제멋대로네요..이거 혹시 정렬이 가능할까요? 기능상 문제는 아니라 여유있을 때 한 번만 도와주세요!


## 💬 기타 참고 사항 (선택)
<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->
- hover했을 때 색상은 primary-100(하늘색)으로 하였습니다. 변경 원하시면 의견 주세요!
- 처음에 ...props로 prop을 다 받을 수 있게 열었다가, 굳이 필요할까 싶어 classname, children, onclick 등 각 컴포넌트에서 지정한 props만 받도록 수정하였습니다. 혹시 더 추가할 prop이 있거나, props를 다 열어두는게 낫다고 생각하시면 말씀해주세요.
