### PR TITLE
체험관리 카드 컴포넌트 구현

### DIFF
--- a/packages/design-system/src/components/ExperienceCard.tsx
+++ b/packages/design-system/src/components/ExperienceCard.tsx
@@ -1,0 +1,54 @@
+import { StarIcon } from '@components/icons';
+
+interface ExperienceCardProps {
+  title: string;
+  price: number;
+  bannerImageUrl: string;
+  rating: number;
+  reviewCount: number;
+  onEdit: () => void;
+  onDelete: () => void;
+}
+
+export default function ExperienceCard({
+  title,
+  price,
+  bannerImageUrl,
+  rating,
+  reviewCount,
+  onEdit,
+  onDelete,
+}: ExperienceCardProps) {
+  const baseButtonClass = 'h-29 cursor-pointer rounded-lg border border-gray-50 px-9 py-4 leading-none';
+  const hoverButtonClass = 'hover:outline-2 hover:outline-gray-200';
+
+  return (
+    <div className='flex w-full justify-between gap-22 rounded-3xl p-24 shadow-[0px_4px_24px_rgba(156,180,202,0.2)] xl:p-30'>
+      <div className='flex flex-col gap-12 xl:gap-20'>
+        <div className='flex flex-col gap-10 xl:gap-10'>
+          <div className='flex flex-col gap-6 xl:gap-10'>
+            <div className='xl:text-2lg text-lg font-bold text-gray-950'>{title}</div>
+            <div className='flex items-center gap-2 text-sm text-gray-500'>
+              <StarIcon filled className='size-14 xl:size-16' />
+              <span>{rating}</span>
+              <span>({reviewCount})</span>
+            </div>
+          </div>
+          <div className='flex items-center gap-4'>
+            <span className='xl:text-2lg text-lg font-bold text-gray-950'>₩{price}</span>
+            <span className='text-md font-medium text-gray-400 xl:text-lg'>/인</span>
+          </div>
+        </div>
+        <div className='text-md flex gap-8 text-gray-600'>
+          <button className={`${baseButtonClass} ${hoverButtonClass} bg-white`} onClick={onEdit}>
+            수정하기
+          </button>
+          <button className={`${baseButtonClass} ${hoverButtonClass} bg-gray-50`} onClick={onDelete}>
+            삭제하기
+          </button>
+        </div>
+      </div>
+      <img className='size-82 rounded-[20px] xl:size-142' src={bannerImageUrl} />
+    </div>
+  );
+}

--- a/packages/design-system/src/components/ExperienceCard.tsx
+++ b/packages/design-system/src/components/ExperienceCard.tsx
@@ -1,15 +1,59 @@
 import { StarIcon } from '@components/icons';
 
 interface ExperienceCardProps {
+  /**
+   * 체험 제목
+   */
   title: string;
+  /**
+   * 체험 가격 (숫자, 원 단위)
+   */
   price: number;
+  /**
+   * 체험 썸네일 이미지 URL
+   */
   bannerImageUrl: string;
+  /**
+   * 체험 평점 (예: 4.8)
+   */
   rating: number;
+  /**
+   * 리뷰 수 (예: 123)
+   */
   reviewCount: number;
+  /**
+   * '수정하기' 버튼 클릭 시 호출될 함수
+   */
   onEdit: () => void;
+  /**
+   * '삭제하기' 버튼 클릭 시 호출될 함수
+   */
   onDelete: () => void;
 }
 
+/**
+ * ExperienceCard 컴포넌트
+ *
+ * - 체험 정보를 카드 형태로 보여주는 컴포넌트입니다.
+ * - 제목, 평점, 가격, 리뷰 수, 배너 이미지와 함께 '수정하기' / '삭제하기' 버튼을 제공합니다.
+ *
+ * @component
+ * @param {ExperienceCardProps} props - 체험 정보 및 버튼 이벤트 핸들러
+ * @returns {JSX.Element} 체험 카드 UI
+ *
+ * @example
+ * ```tsx
+ * <ExperienceCard
+ *   title="쿠킹 클래스"
+ *   price={35000}
+ *   bannerImageUrl="/images/cooking.jpg"
+ *   rating={4.8}
+ *   reviewCount={129}
+ *   onEdit={() => console.log('edit')}
+ *   onDelete={() => console.log('delete')}
+ * />
+ * ```
+ */
 export default function ExperienceCard({
   title,
   price,
@@ -19,36 +63,35 @@ export default function ExperienceCard({
   onEdit,
   onDelete,
 }: ExperienceCardProps) {
-  const baseButtonClass = 'h-29 cursor-pointer rounded-lg border border-gray-50 px-9 py-4 leading-none';
-  const hoverButtonClass = 'hover:outline-2 hover:outline-gray-200';
+  const formatPrice = (value: number) => value.toLocaleString('ko');
+  const buttonClass =
+    'h-29 cursor-pointer rounded-lg border border-gray-50 px-9 py-4 leading-none hover:outline-2 hover:outline-gray-200';
 
   return (
-    <div className='flex w-full justify-between gap-22 rounded-3xl p-24 shadow-[0px_4px_24px_rgba(156,180,202,0.2)] xl:p-30'>
-      <div className='flex flex-col gap-12 xl:gap-20'>
-        <div className='flex flex-col gap-10 xl:gap-10'>
-          <div className='flex flex-col gap-6 xl:gap-10'>
-            <div className='xl:text-2lg text-lg font-bold text-gray-950'>{title}</div>
-            <div className='flex items-center gap-2 text-sm text-gray-500'>
-              <StarIcon filled className='size-14 xl:size-16' />
-              <span>{rating}</span>
-              <span>({reviewCount})</span>
-            </div>
+    <article className='flex w-full justify-between gap-22 rounded-3xl p-24 shadow-[0px_4px_24px_rgba(156,180,202,0.2)] xl:p-30'>
+      <div className='flex flex-col gap-12 xl:gap-14'>
+        <header className='flex flex-col gap-6 xl:gap-8'>
+          <h3 className='xl:text-2lg text-lg font-bold text-gray-950'>{title}</h3>
+          <div className='flex items-center gap-2 text-sm text-gray-500 xl:text-lg'>
+            <StarIcon filled className='size-14 xl:size-16' />
+            <span>{rating}</span>
+            <span>({reviewCount})</span>
           </div>
-          <div className='flex items-center gap-4'>
-            <span className='xl:text-2lg text-lg font-bold text-gray-950'>₩{price}</span>
-            <span className='text-md font-medium text-gray-400 xl:text-lg'>/인</span>
-          </div>
+        </header>
+        <div className='flex items-center gap-4'>
+          <span className='xl:text-2lg text-lg font-bold text-gray-950'>₩{formatPrice(price)}</span>
+          <span className='text-md font-medium text-gray-400 xl:text-lg'>/인</span>
         </div>
-        <div className='text-md flex gap-8 text-gray-600'>
-          <button className={`${baseButtonClass} ${hoverButtonClass} bg-white`} onClick={onEdit}>
+        <div className='text-md flex gap-8 text-gray-600' role='group'>
+          <button className={`${buttonClass} bg-white`} onClick={onEdit}>
             수정하기
           </button>
-          <button className={`${baseButtonClass} ${hoverButtonClass} bg-gray-50`} onClick={onDelete}>
+          <button className={`${buttonClass} bg-gray-50`} onClick={onDelete}>
             삭제하기
           </button>
         </div>
       </div>
-      <img className='size-82 rounded-[20px] xl:size-142' src={bannerImageUrl} />
-    </div>
+      <img alt='체험 배너 이미지' className='size-82 rounded-[20px] xl:size-142' src={bannerImageUrl} />
+    </article>
   );
 }

--- a/packages/design-system/src/layouts/Sidebar.tsx
+++ b/packages/design-system/src/layouts/Sidebar.tsx
@@ -18,6 +18,7 @@ export default function DesignSystemLayout() {
             <SidebarNavItem label='Pagination' to='/docs/Pagination' />
             <SidebarNavItem label='Calendar' to='/docs/Calendar' />
             <SidebarNavItem label='Dropdown' to='/docs/Dropdown' />
+            <SidebarNavItem label='ExperienceCard' to='/docs/ExperienceCard' />
           </ul>
         </nav>
       </aside>

--- a/packages/design-system/src/pages/ExperienceCardDoc.tsx
+++ b/packages/design-system/src/pages/ExperienceCardDoc.tsx
@@ -1,0 +1,76 @@
+import ExperienceCard from '@/components/ExperienceCard';
+import DocTemplate, { DocCode } from '@/layouts/DocTemplate';
+import Playground from '@/layouts/Playground';
+
+/* Playground는 편집 가능한 코드 블록입니다. */
+/* Playground에서 사용할 예시 코드를 작성해주세요. */
+const code = `<ExperienceCard title='내가 등록한 체험 제목입니다' price={8000} bannerImageUrl='https://www.urbanbrush.net/web/wp-content/uploads/edd/2023/02/urban-20230228144115810458.jpg' rating={4.5} reviewCount={161} onEdit={()=>console.log('수정하기')} onDelete={()=>console.log('삭제하기')}/>`;
+
+export default function ExperienceCardDoc() {
+  return (
+    <>
+      <DocTemplate
+        description={`
+체험 카드 컴포넌트는 체험/클래스 상품 정보를 시각적으로 표현하기 위한 요소입니다.  
+제목, 가격, 이미지, 평점, 리뷰 수, 그리고 수정/삭제 버튼 등의 기능을 포함합니다.
+
+아래는 기본적인 사용 예시입니다:
+
+\`\`\`tsx
+import { ExperienceCard } from '@what-today/design-system';
+
+<ExperienceCard
+  title="도예 원데이 클래스"
+  price={30000}
+  bannerImageUrl="https://source.unsplash.com/random/300x200?ceramics"
+  rating={4.8}
+  reviewCount={92}
+  onEdit={() => {}}
+  onDelete={() => {}}
+/>
+\`\`\`
+`}
+        propsDescription={`
+| Prop           | Type            | Required | Description                        |
+|----------------|-----------------|----------|------------------------------------|
+| title          | string          | Yes      | 체험 제목                          |
+| price          | number          | Yes      | 1인 가격                           |
+| bannerImageUrl | string          | Yes      | 배너 이미지 URL                    |
+| rating         | number          | Yes      | 별점 (0~5)                         |
+| reviewCount    | number          | Yes      | 리뷰 수                            |
+| onEdit         | () => void      | Yes      | '수정하기' 버튼 클릭 시 핸들러     |
+| onDelete       | () => void      | Yes      | '삭제하기' 버튼 클릭 시 핸들러     |
+`}
+        title='ExperienceCard'
+      />
+      {/* 실제 컴포넌트를 아래에 작성해주세요 */}
+      {/* 예시 코드 */}
+      <h3 className='mb-8 text-base font-semibold text-gray-600'>기본 예시</h3>
+      <ExperienceCard
+        bannerImageUrl='https://imgcp.aacdn.jp/img-a/1200/auto/global-aaj-front/article/2018/04/5ad9a61f500f3_5ad9a4902c586_1026847964.jpg'
+        price={30000}
+        rating={4.8}
+        reviewCount={92}
+        title='도예 원데이 클래스'
+        onDelete={() => {}}
+        onEdit={() => {}}
+      />
+      <DocCode
+        code={`<ExperienceCard
+  title="도예 원데이 클래스"
+  price={30000}
+  bannerImageUrl='https://imgcp.aacdn.jp/img-a/1200/auto/global-aaj-front/article/2018/04/5ad9a61f500f3_5ad9a4902c586_1026847964.jpg'
+  rating={4.8}
+  reviewCount={92}
+  onEdit={() => {}}
+  onDelete={() => {}}
+/>`}
+      />
+
+      {/* Playground는 편집 가능한 코드 블록입니다. */}
+      <div className='mt-24'>
+        <Playground code={code} scope={{ ExperienceCard }} />
+      </div>
+    </>
+  );
+}

--- a/packages/design-system/src/routes/index.tsx
+++ b/packages/design-system/src/routes/index.tsx
@@ -1,8 +1,9 @@
 import ButtonExampleDocs from '@pages/ButtonExampleDocs';
-import InputDoc from '@pages/InputDoc';
 import CalendarDoc from '@pages/CalendarDoc';
 import DropdownDoc from '@pages/DropdownDoc';
+import ExperienceCardDoc from '@pages/ExperienceCardDoc';
 import IconDoc from '@pages/IconDoc';
+import InputDoc from '@pages/InputDoc';
 import LandingPage from '@pages/LandingPage';
 import LogoDoc from '@pages/LogoDoc';
 import PaginationDoc from '@pages/PaginationDoc';
@@ -26,6 +27,10 @@ const router = createBrowserRouter([
       {
         path: 'button-example',
         element: <ButtonExampleDocs />,
+      },
+      {
+        path: 'ExperienceCard',
+        element: <ExperienceCardDoc />,
       },
       {
         path: 'Input',


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- 이슈 번호 #48 

## 📌 작업 내용
<!-- 해당 PR의 변경 사항을 자세하게 적어주세요.-->
- 체험관리 카드 컴포넌트 구현 (Experience Card)
- '내 체험 리스트 조회' api에서 받아오는 내역 props로 전달받음
- 수정하기, 삭제하기 버튼 클릭시 실행할 함수 props로 전달받음

## ✅ 체크리스트

- [x] PR 하기 전에 이슈에서 빼먹은건 없는지 확인했습니다
  - [x] 라벨 및 마일스톤을 사이드 탭에서 등록했습니다.
- [x] PR을 보내는 브랜치가 올바른지 확인했습니다.
- [x] 팀원들이 리뷰하기 쉽도록 설명을 자세하게 작성했습니다.
- [x] 변경사항을 충분히 테스트 했습니다.
- [x] (함수를 구현 했을 때) JSDoc을 양식에 맞춰서 작성했습니다.
- [x] 컨벤션에 맞게 구현했습니다.

## 📷 UI 변경 사항 (선택)
<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->
<img width="1179" height="226" alt="image" src="https://github.com/user-attachments/assets/febec1ff-4c3c-4ee5-9034-8c857d0451fb" />

영상은 다른 곳에서 테스트해서 별모양 아이콘 대신 임시 별입니다. 실제 컴포넌트는 StarIcon 사용했어요!

https://github.com/user-attachments/assets/a5200cdf-f9f5-4fc7-be10-6aa0a988f54d


## ❓무슨 문제가 발생했나요? (선택)

-

## 💬 기타 참고 사항 (선택)
<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->
- hover했을 때 outline을 강조해줬는데, 굳이 필요없으면 빼도 될 것 같아요. 의견 남겨주시면 반영하겠습니다!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 경험/클래스 상품 정보를 카드 형식으로 보여주는 `ExperienceCard` 컴포넌트가 추가되었습니다.
  * `ExperienceCard` 컴포넌트의 문서 페이지가 새롭게 제공되며, 사용 예시와 Playground(실시간 코드 편집 및 미리보기) 기능이 포함되어 있습니다.
  * 사이드바와 라우터에 `ExperienceCard` 문서로 이동할 수 있는 항목이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->