### PR TITLE
예약내역 카드 컴포넌트 구현

### DIFF
--- a/packages/design-system/src/components/ReservationCard.tsx
+++ b/packages/design-system/src/components/ReservationCard.tsx
@@ -1,13 +1,63 @@
 interface ReservationCardProps {
+  /**
+   * 체험 제목
+   */
   title: string;
+  /**
+   * 체험 썸네일 이미지 URL
+   */
   bannerImageUrl: string;
+  /**
+   * 예약 상태
+   * - pending: 체험 완료
+   * - confirmed: 예약 승인
+   * - declined: 예약 거절
+   * - canceled: 예약 취소
+   * - completed: 예약 완료
+   */
   status: 'pending' | 'confirmed' | 'declined' | 'canceled' | 'completed';
+  /**
+   * 총 가격 (₩)
+   */
   totalPrice: number;
+  /**
+   * 인원 수
+   */
   headCount: number;
+  /**
+   * 체험 시작 시간 ('HH:mm', 24시간제 시각 문자열)
+   */
   startTime: string;
+  /**
+   * 체험 종료 시간 ('HH:mm', 24시간제 시각 문자열)
+   */
   endTime: string;
 }
 
+/**
+ * ReservationCard 컴포넌트
+ *
+ * - 체험 예약 정보를 카드 형태로 보여주는 UI입니다.
+ * - 제목, 배너 이미지, 예약 상태, 가격, 인원, 시간 등의 정보를 표시합니다.
+ * - 예약 상태는 `badge`와 색상(`style`)으로 시각화됩니다.
+ *
+ * @component
+ * @param {ReservationCardProps} props - 예약 정보 및 상태 관련 데이터
+ * @returns {JSX.Element} 예약 카드 UI
+ *
+ * @example
+ * ```tsx
+ * <ReservationCard
+ *   title="요가 클래스"
+ *   bannerImageUrl="/images/yoga.jpg"
+ *   status="confirmed"
+ *   totalPrice={54000}
+ *   headCount={2}
+ *   startTime="2025-08-01T10:00"
+ *   endTime="2025-08-01T11:00"
+ * />
+ * ```
+ */
 export default function ReservationCard({
   title,
   bannerImageUrl,
@@ -18,6 +68,7 @@ export default function ReservationCard({
   endTime,
 }: ReservationCardProps) {
   const formatPrice = (value: number) => value.toLocaleString('ko');
+  // badge 컴포넌트로 수정 예정
   const reservationStatus = {
     pending: { badge: '체험 완료', style: 'bg-[#DAF0FF] text-[#0D6CD1]' },
     confirmed: { badge: '예약 승인', style: 'bg-[#DDF9F9] text-[#1790A0]' },
@@ -28,24 +79,24 @@ export default function ReservationCard({
   const { badge, style } = reservationStatus[status];
 
   return (
-    <div className='flex -space-x-38 rounded-3xl shadow-[0px_4px_24px_rgba(156,180,202,0.2)] md:-space-x-20 xl:max-w-640 xl:-space-x-26'>
-      <div className='z-10 flex h-136 w-full flex-col justify-between rounded-3xl bg-white p-20 shadow-[0px_-8px_20px_0px_rgba(0,0,0,0.05)] xl:h-181 xl:px-40 xl:py-30'>
-        <div className='flex flex-col xl:gap-4'>
+    <article className='flex -space-x-38 rounded-3xl shadow-[0px_4px_24px_rgba(156,180,202,0.2)] md:-space-x-20 xl:max-w-640 xl:-space-x-26'>
+      <section className='z-10 flex h-136 w-full flex-col justify-between rounded-3xl bg-white p-20 shadow-[0px_-8px_20px_0px_rgba(0,0,0,0.05)] xl:h-181 xl:px-40 xl:py-30'>
+        <header className='flex flex-col xl:gap-4'>
           <div className='flex flex-col gap-4 xl:gap-8'>
             {/* badge 컴포넌트로 수정 예정 */}
-            <div className={`z-10 w-63 rounded-full px-6 py-1 text-center text-sm font-bold ${style}`}>{badge}</div>
-            <div className='xl:text-2lg text-sm font-bold text-gray-950'>{title}</div>
+            <span className={`w-63 rounded-full px-6 py-1 text-center text-sm font-bold ${style}`}>{badge}</span>
+            <h3 className='xl:text-2lg text-sm font-bold text-gray-950'>{title}</h3>
           </div>
           <div className='text-sm font-medium text-gray-500 xl:text-lg'>
-            {startTime}-{endTime}
+            <time dateTime={startTime}>{startTime}</time>-<time dateTime={endTime}>{endTime}</time>
           </div>
-        </div>
+        </header>
         <div className='flex items-center gap-4'>
           <div className='xl:text-2lg text-lg font-bold text-gray-950'>₩{formatPrice(totalPrice)}</div>
           <div className='text-md font-medium text-gray-400 xl:text-lg'>{headCount}명</div>
         </div>
-      </div>
-      <img className='size-136 rounded-r-3xl xl:size-181' src={bannerImageUrl} />
-    </div>
+      </section>
+      <img alt={`${title} 체험 배너`} className='size-136 rounded-r-3xl xl:size-181' src={bannerImageUrl} />
+    </article>
   );
 }

--- a/packages/design-system/src/components/ReservationCard.tsx
+++ b/packages/design-system/src/components/ReservationCard.tsx
@@ -1,0 +1,51 @@
+interface ReservationCardProps {
+  title: string;
+  bannerImageUrl: string;
+  status: 'pending' | 'confirmed' | 'declined' | 'canceled' | 'completed';
+  totalPrice: number;
+  headCount: number;
+  startTime: string;
+  endTime: string;
+}
+
+export default function ReservationCard({
+  title,
+  bannerImageUrl,
+  status,
+  totalPrice,
+  headCount,
+  startTime,
+  endTime,
+}: ReservationCardProps) {
+  const formatPrice = (value: number) => value.toLocaleString('ko');
+  const reservationStatus = {
+    pending: { badge: '체험 완료', style: 'bg-[#DAF0FF] text-[#0D6CD1]' },
+    confirmed: { badge: '예약 승인', style: 'bg-[#DDF9F9] text-[#1790A0]' },
+    declined: { badge: '예약 거절', style: 'bg-[#FCECEA] text-[#F96767]' },
+    canceled: { badge: '예약 취소', style: 'bg-[#E0E0E5] text-[#707177]' },
+    completed: { badge: '예약 완료', style: 'bg-[#E9FBE4] text-[#2BA90D]' },
+  };
+  const { badge, style } = reservationStatus[status];
+
+  return (
+    <div className='flex -space-x-38 rounded-3xl shadow-[0px_4px_24px_rgba(156,180,202,0.2)] md:-space-x-20 xl:max-w-640 xl:-space-x-26'>
+      <div className='z-10 flex h-136 w-full flex-col justify-between rounded-3xl bg-white p-20 shadow-[0px_-8px_20px_0px_rgba(0,0,0,0.05)] xl:h-181 xl:px-40 xl:py-30'>
+        <div className='flex flex-col xl:gap-4'>
+          <div className='flex flex-col gap-4 xl:gap-8'>
+            {/* badge 컴포넌트로 수정 예정 */}
+            <div className={`z-10 w-63 rounded-full px-6 py-1 text-center text-sm font-bold ${style}`}>{badge}</div>
+            <div className='xl:text-2lg text-sm font-bold text-gray-950'>{title}</div>
+          </div>
+          <div className='text-sm font-medium text-gray-500 xl:text-lg'>
+            {startTime}-{endTime}
+          </div>
+        </div>
+        <div className='flex items-center gap-4'>
+          <div className='xl:text-2lg text-lg font-bold text-gray-950'>₩{formatPrice(totalPrice)}</div>
+          <div className='text-md font-medium text-gray-400 xl:text-lg'>{headCount}명</div>
+        </div>
+      </div>
+      <img className='size-136 rounded-r-3xl xl:size-181' src={bannerImageUrl} />
+    </div>
+  );
+}

--- a/packages/design-system/src/components/ReservationCard.tsx
+++ b/packages/design-system/src/components/ReservationCard.tsx
@@ -9,11 +9,11 @@ interface ReservationCardProps {
   bannerImageUrl: string;
   /**
    * 예약 상태
-   * - pending: 체험 완료
+   * - pending: 신청 완료
    * - confirmed: 예약 승인
    * - declined: 예약 거절
    * - canceled: 예약 취소
-   * - completed: 예약 완료
+   * - completed: 체험 완료
    */
   status: 'pending' | 'confirmed' | 'declined' | 'canceled' | 'completed';
   /**

--- a/packages/design-system/src/components/index.ts
+++ b/packages/design-system/src/components/index.ts
@@ -3,6 +3,6 @@ export * from './icons';
 export * from './input';
 export * from './logos';
 export { default as Pagination } from './Pagination';
+export { default as ReservationCard } from './ReservationCard';
 export * from '@/components/calendar/index';
 export * from '@/components/dropdown/index';
-export * from '@/components/ReservationCard';

--- a/packages/design-system/src/components/index.ts
+++ b/packages/design-system/src/components/index.ts
@@ -1,7 +1,8 @@
 export { default as Button } from './Button';
-export * from './input';
 export * from './icons';
+export * from './input';
 export * from './logos';
 export { default as Pagination } from './Pagination';
 export * from '@/components/calendar/index';
 export * from '@/components/dropdown/index';
+export * from '@/components/ReservationCard';

--- a/packages/design-system/src/layouts/Sidebar.tsx
+++ b/packages/design-system/src/layouts/Sidebar.tsx
@@ -18,6 +18,7 @@ export default function DesignSystemLayout() {
             <SidebarNavItem label='Pagination' to='/docs/Pagination' />
             <SidebarNavItem label='Calendar' to='/docs/Calendar' />
             <SidebarNavItem label='Dropdown' to='/docs/Dropdown' />
+            <SidebarNavItem label='ReservationCard' to='/docs/ReservationCard' />
           </ul>
         </nav>
       </aside>

--- a/packages/design-system/src/pages/ReservationCardDoc.tsx
+++ b/packages/design-system/src/pages/ReservationCardDoc.tsx
@@ -1,0 +1,81 @@
+import ReservationCard from '@/components/ReservationCard';
+import DocTemplate from '@/layouts/DocTemplate';
+import Playground from '@/layouts/Playground';
+
+/* Playground는 편집 가능한 코드 블록입니다. */
+/* Playground에서 사용할 예시 코드를 작성해주세요. */
+const code = `<ReservationCard title='예약하신 체험 제목입니다. '
+  bannerImageUrl='https://www.urbanbrush.net/web/wp-content/uploads/edd/2023/02/urban-20230228144115810458.jpg'
+  status='canceled'
+  totalPrice={16000}
+  headCount={5}
+  startTime='13:00'
+  endTime='15:00'/>`;
+
+export default function ReservationCardDoc() {
+  return (
+    <>
+      <DocTemplate
+        description={`
+ReservationCard 컴포넌트는 체험 예약 정보를 카드 형태로 시각화합니다.  
+예약 상태에 따라 badge 색상이 동적으로 달라지며,  
+체험 시간, 인원, 가격 정보를 한 눈에 보여주는 UI 구성 요소입니다.
+
+아래는 기본적인 사용 예시입니다:
+
+\`\`\`tsx
+import { ReservationCard } from '@what-today/design-system';
+
+<ReservationCard
+  title="요가 클래스"
+  bannerImageUrl="/images/yoga.jpg"
+  status="confirmed"
+  totalPrice={54000}
+  headCount={2}
+  startTime="10:00"
+  endTime="11:00"
+/>
+\`\`\`
+`}
+        propsDescription={`
+| Prop           | Type                                                                 | Required | Description                               |
+|----------------|----------------------------------------------------------------------|----------|-------------------------------------------|
+| title          | \`string\`                                                           | Yes      | 체험 제목                                  |
+| bannerImageUrl | \`string\`                                                           | Yes      | 썸네일 이미지 URL                          |
+| status         | \`string\` | Yes      | 예약 상태("pending", "confirmed", "declined", "canceled", "completed")                                 |
+| totalPrice     | \`number\`                                                           | Yes      | 총 가격 (₩)                               |
+| headCount      | \`number\`                                                           | Yes      | 인원 수                                    |
+| startTime      | \`string\`                                                           | Yes      | 시작 시간 (24시간제 'HH:mm' 포맷)        |
+| endTime        | \`string\`                                                           | Yes      | 종료 시간 (24시간제 'HH:mm' 포맷)        |
+`}
+        title='ReservationCard'
+      />
+      {/* 실제 컴포넌트를 아래에 작성해주세요 */}
+      {/* 예시 코드 */}
+      <h3 className='mb-8 text-base font-semibold text-gray-600'>기본 예시</h3>
+      <ReservationCard
+        bannerImageUrl='https://www.urbanbrush.net/web/wp-content/uploads/edd/2023/02/urban-20230228144115810458.jpg'
+        endTime='11:00'
+        headCount={2}
+        startTime='10:00'
+        status='confirmed'
+        title='요가 클래스'
+        totalPrice={54000}
+      />
+      {/* <DocCode code={`<ReservationCard
+          title="요가 클래스"
+          bannerImageUrl="https://www.urbanbrush.net/web/wp-content/uploads/edd/2023/02/urban-20230228144115810458.jpg"
+          status="confirmed"
+          totalPrice={54000}
+          headCount={2}
+          startTime="10:00"
+          endTime="11:00"
+        />`} /> */}
+
+      {/* Playground는 편집 가능한 코드 블록입니다. */}
+      <div className='mt-24'>
+        <Playground code={code} scope={{ ReservationCard }} />
+      </div>
+    </>
+  );
+}

--- a/packages/design-system/src/routes/index.tsx
+++ b/packages/design-system/src/routes/index.tsx
@@ -1,11 +1,12 @@
 import ButtonExampleDocs from '@pages/ButtonExampleDocs';
-import InputDoc from '@pages/InputDoc';
 import CalendarDoc from '@pages/CalendarDoc';
 import DropdownDoc from '@pages/DropdownDoc';
 import IconDoc from '@pages/IconDoc';
+import InputDoc from '@pages/InputDoc';
 import LandingPage from '@pages/LandingPage';
 import LogoDoc from '@pages/LogoDoc';
 import PaginationDoc from '@pages/PaginationDoc';
+import ReservationCardDoc from '@pages/ReservationCardDoc';
 import { createBrowserRouter, Navigate } from 'react-router-dom';
 
 import Sidebar from '@/layouts/Sidebar';
@@ -26,6 +27,10 @@ const router = createBrowserRouter([
       {
         path: 'button-example',
         element: <ButtonExampleDocs />,
+      },
+      {
+        path: 'ReservationCard',
+        element: <ReservationCardDoc />,
       },
       {
         path: 'Input',


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- 이슈 번호 #50 

## 📌 작업 내용
<!-- 해당 PR의 변경 사항을 자세하게 적어주세요.-->
- 예약내역 카드 컴포넌트 구현(ReservationCard)
- '내 예약 리스트 조회' api에서 받아오는 내역 props로 전달받음
- 예약 상태에 따라 다른 뱃지 표기

## ✅ 체크리스트

- [x] PR 하기 전에 이슈에서 빼먹은건 없는지 확인했습니다
  - [x] 라벨 및 마일스톤을 사이드 탭에서 등록했습니다.
- [x] PR을 보내는 브랜치가 올바른지 확인했습니다.
- [x] 팀원들이 리뷰하기 쉽도록 설명을 자세하게 작성했습니다.
- [x] 변경사항을 충분히 테스트 했습니다.
- [x] (함수를 구현 했을 때) JSDoc을 양식에 맞춰서 작성했습니다.
- [x] 컨벤션에 맞게 구현했습니다.

## 📷 UI 변경 사항 (선택)
<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->
<img width="582" height="158" alt="image" src="https://github.com/user-attachments/assets/6a041bf9-c738-4b02-af75-eac99a690305" />
<img width="666" height="208" alt="image" src="https://github.com/user-attachments/assets/3c4898ed-7f30-4be6-9833-dc96ddb0d9de" />


## ❓무슨 문제가 발생했나요? (선택)

-

## 💬 기타 참고 사항 (선택)
<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->

-
