### PR TITLE
NoResult 공통 컴포넌트 구현

### DIFF
--- a/packages/design-system/src/components/NoResult.tsx
+++ b/packages/design-system/src/components/NoResult.tsx
@@ -36,12 +36,7 @@ export default function NoResult({
     <div className='flex w-fit flex-col items-center gap-24 md:gap-32'>
       <EmptyLogo className='size-100 md:size-140' />
       <p className='text-lg text-gray-800'>앗, 아직 {dataName} 없습니다.</p>
-      <Button
-        className='w-full px-8 py-4 font-normal'
-        size='xs'
-        variant='outline'
-        onClick={() => navigate(redirectPath)}
-      >
+      <Button className='w-full font-normal' size='xs' variant='outline' onClick={() => navigate(redirectPath)}>
         {buttonMessage}
       </Button>
     </div>

--- a/packages/design-system/src/components/NoResult.tsx
+++ b/packages/design-system/src/components/NoResult.tsx
@@ -1,0 +1,49 @@
+import { useNavigate } from 'react-router-dom';
+
+import Button from './button';
+import { EmptyLogo } from './logos';
+
+interface NoResultProps {
+  dataName?: string;
+  buttonMessage?: string;
+  redirectPath?: string;
+}
+
+/** NoResult
+ * @description 데이터를 찾을 수 없을 때 사용자에게 피드백을 주는 컴포넌트입니다. 버튼 클릭 시 지정된 경로로 이동합니다.
+ *
+ * @param dataName - "앗, 아직 {dataName} 없습니다."에 들어갈 dataName (default: 데이터가)
+ * @param buttonMessage - 버튼에 표시할 텍스트 (예: '추천 보러가기') (default: 둘러보기)
+ * @param redirectPath - 버튼 클릭 시 이동할 라우터 경로 (예: '/login') (default: /)
+ *
+ * @example
+ * ```tsx
+ * <NoResult
+ *   dataName="예약 내역이"
+ *   buttonMessage="예약하러 가기"
+ *   redirectPath="/mypage"
+ * />
+ * ```
+ */
+export default function NoResult({
+  dataName = '데이터가',
+  buttonMessage = '둘러보기',
+  redirectPath = '/',
+}: NoResultProps) {
+  const navigate = useNavigate();
+
+  return (
+    <div className='flex w-fit flex-col items-center gap-24 md:gap-32'>
+      <EmptyLogo className='size-100 md:size-140' />
+      <p className='text-lg text-gray-800'>앗, 아직 {dataName} 없습니다.</p>
+      <Button
+        className='w-full px-8 py-4 font-normal'
+        size='xs'
+        variant='outline'
+        onClick={() => navigate(redirectPath)}
+      >
+        {buttonMessage}
+      </Button>
+    </div>
+  );
+}

--- a/packages/design-system/src/layouts/Sidebar.tsx
+++ b/packages/design-system/src/layouts/Sidebar.tsx
@@ -21,12 +21,11 @@ export default function DesignSystemLayout() {
 
             <SidebarNavItem label='Calendar' to='/docs/Calendar' />
 
-
-
             <SidebarNavItem label='Textarea' to='/docs/Textarea' />
 
             <SidebarNavItem label='Dropdown' to='/docs/Dropdown' />
             <SidebarNavItem label='ExperienceCard' to='/docs/ExperienceCard' />
+            <SidebarNavItem label='NoResult' to='/docs/NoResult' />
           </ul>
         </nav>
       </aside>

--- a/packages/design-system/src/pages/NoResultDoc.tsx
+++ b/packages/design-system/src/pages/NoResultDoc.tsx
@@ -1,0 +1,47 @@
+import Playground from '@/layouts/Playground';
+
+import NoResult from '../components/NoResult';
+import DocTemplate, { DocCode } from '../layouts/DocTemplate';
+
+/* Playground는 편집 가능한 코드 블록입니다. */
+/* Playground에서 사용할 예시 코드를 작성해주세요. */
+const code = `<NoResult buttonMessage='예약하러 가기' dataName='예약 내역이' redirectPath='/docs/button' />`;
+
+export default function NoResultDoc() {
+  return (
+    <>
+      <DocTemplate
+        description={`
+데이터가 없을 때 보여질 컴포넌트입니다.  
+고정적으로 \`로고 이미지\` / \`데이터 없음 문구\` / \`버튼\`으로 구성되어 있으며, 버튼을 누르면 다른 페이지로 리다이렉트합니다.  
+
+단순한 UI라서 스타일 확장은 고려하지 않았습니다.  
+그래서 간단하게 데스크탑/태블릿과 모바일에서 이미지 크기를 다르게 설정해두었습니다. (차이가 크지는 않습니다..ㅎㅎ)
+
+
+`}
+        propsDescription={`
+| 이름 | 타입 | 설명 | 기본 값 |
+|------|------|------|----|
+| dataName  | \`string?\`     |    \`앗, 아직 {dataName} 없습니다\`에 해당하는 문구 (데이터 종류)      |\`데이터가\`|
+| buttonMessage   | \`string?\`  | 리다이렉트 버튼에 나타날 문구             |\`둘러보기\`|
+| redirectPath   | \`string?\`  | 버튼을 눌렀을 때 리다이렉트할 링크 (ex. \`/mypage\`, \`/login\`) |\`/\`|
+`}
+        title='NoResult'
+      />
+      {/* 실제 컴포넌트를 아래에 작성해주세요 */}
+      {/* 예시 코드 */}
+      <div className='my-12'>
+        <NoResult buttonMessage='예약하러 가기' dataName='예약 내역이' redirectPath='/docs/button' />
+      </div>
+      <DocCode
+        code={` <NoResult buttonMessage='예약하러 가기' dataName='예약 내역이' redirectPath='/docs/button' />`}
+      />
+
+      {/* Playground는 편집 가능한 코드 블록입니다. */}
+      <div className='mt-24'>
+        <Playground code={code} scope={{ NoResult }} />
+      </div>
+    </>
+  );
+}

--- a/packages/design-system/src/routes/index.tsx
+++ b/packages/design-system/src/routes/index.tsx
@@ -7,6 +7,7 @@ import IconDoc from '@pages/IconDoc';
 import InputDoc from '@pages/InputDoc';
 import LandingPage from '@pages/LandingPage';
 import LogoDoc from '@pages/LogoDoc';
+import NoResultDoc from '@pages/NoResultDoc';
 import PaginationDoc from '@pages/PaginationDoc';
 import RadioGroupDoc from '@pages/RadioGroupDoc';
 import TextareaDoc from '@pages/TextareaDoc';
@@ -24,6 +25,10 @@ const router = createBrowserRouter([
       {
         path: '',
         element: <LandingPage />,
+      },
+      {
+        path: 'NoResult',
+        element: <NoResultDoc />,
       },
       {
         path: 'button',


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- #61

## 📌 작업 내용
<!-- 해당 PR의 변경 사항을 자세하게 적어주세요.-->

데이터가 없을 때 보여질 컴포넌트입니다.
고정적으로 로고 이미지 / 데이터 없음 문구 / 버튼으로 구성되어 있으며, 버튼을 누르면 다른 페이지로 리다이렉트합니다.

단순한 UI라서 스타일 확장은 고려하지 않았습니다.
그래서 간단하게 데스크탑/태블릿과 모바일에서 이미지 크기를 다르게 설정해두었습니다. (차이가 크지는 않습니다..ㅎㅎ)


## ✅ 체크리스트

- [ ] PR 하기 전에 이슈에서 빼먹은건 없는지 확인했습니다
  - [ ] 라벨 및 마일스톤을 사이드 탭에서 등록했습니다.
- [ ] PR을 보내는 브랜치가 올바른지 확인했습니다.
- [ ] 팀원들이 리뷰하기 쉽도록 설명을 자세하게 작성했습니다.
- [ ] 변경사항을 충분히 테스트 했습니다.
- [ ] (함수를 구현 했을 때) JSDoc을 양식에 맞춰서 작성했습니다.
- [ ] 컨벤션에 맞게 구현했습니다.

## 📷 UI 변경 사항 (선택)
<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->

![NoResult](https://github.com/user-attachments/assets/d166d618-aa31-4b36-8eea-ce7596e0f87a)


## ❓무슨 문제가 발생했나요? (선택)

@HarrySeop 

<img width="272" height="138" alt="image" src="https://github.com/user-attachments/assets/ac217f56-eb8e-48c6-9000-3cdeeac91db5" />

현재 작업 내용에 영향이 있는건 아니지만, 
버튼에 기본으로 적용된 `padding`을 그 이하 값으로 수정하면, 외부에서 확장한 `padding` 값이 제대로 적용되지 않는 것 같아요..!
(ex. 버튼 기본 size로 `px-40`으로 설정되어 있을 때, 외부에서 `px-20`을 추가해도 반영이 안됨)

확인 한 번 부탁드려요!~

## 💬 기타 참고 사항 (선택)
<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->

기존 피그마는 브랜드 색상의 버튼을 사용했는데, 실제로 구현해보니 버튼의 색과 로고 이미지의 색과 겹쳐서 outline 버튼으로 변경해보았습니다.
제 개인적인 취향이 반영된거라... 아래 사진 참고하셔서 의견 주시면 감사하겠습니다!
(기본적으로 버튼의 hover 스타일이 정해져있어서, outline 버튼이라도 hover하면 배경색이 변경됩니다!)

|fill|outline|
|---|-------|
|<img width="228" height="249" alt="image" src="https://github.com/user-attachments/assets/631dac81-f26a-4d1e-a523-e5b70e39ddce" />|<img width="243" height="244" alt="image" src="https://github.com/user-attachments/assets/1fb11d25-e02d-4478-9d2b-c12a63c157a5" /><img width="238" height="240" alt="image" src="https://github.com/user-attachments/assets/76bc5e37-b770-4da0-b6a4-5d21b6459d41" />|