### PR TITLE
Badge 컴포넌트 구현

### DIFF
--- a/packages/design-system/src/components/Badge.tsx
+++ b/packages/design-system/src/components/Badge.tsx
@@ -4,11 +4,39 @@ type OwnerStatusProps = 'pending' | 'confirmed' | 'completed';
 type UserStatusProps = OwnerStatusProps | 'declined' | 'canceled';
 type BadgeTypeProps = 'user' | 'owner';
 interface BadgeProps {
+  /**
+   * 사용자 타입에 따른 뱃지 스타일 구분('user' | 'owner')
+   */
   type: BadgeTypeProps;
+  /**
+   * 예약 상태 구분('pending' | 'confirmed' | 'completed' | 'declined' | 'canceled')
+   */
   status: UserStatusProps | OwnerStatusProps;
+  /**
+   * `type`이 `owner`일 경우에만 노출되는 수치 정보
+   */
   count?: number;
 }
 
+/**
+ * Badge 컴포넌트
+ * 예약 상태에 따라 시각적 뱃지를 렌더링하는 컴포넌트입니다.
+ *
+ * @component
+ * @param {BadgeProps} props - 뱃지에 전달되는 props
+ * @param {BadgeTypeProps} props.type - 사용자 타입에 따른 뱃지 스타일 구분
+ * @param {UserStatusProps} props.status - 예약 상태
+ *   - `owner`일 경우에는 `'canceled'`와 `'declined'`는 사용할 수 없습니다.
+ * @param {number} [props.count] - `type`이 `owner`일 경우에만 노출되는 수치 정보
+ *
+ * @returns {JSX.Element} 예약 상태에 따른 스타일링된 뱃지 요소
+ *
+ * @example
+ * <Badge type="user" status="confirmed" />
+ *
+ * @example
+ * <Badge type="owner" status="pending" count={3} />
+ */
 export default function Badge({ type, status, count }: BadgeProps) {
   const isOwner = type === 'owner';
 

--- a/packages/design-system/src/components/Badge.tsx
+++ b/packages/design-system/src/components/Badge.tsx
@@ -1,34 +1,61 @@
+import { twMerge } from 'tailwind-merge';
+
+type OwnerStatusProps = 'pending' | 'confirmed' | 'completed';
+type UserStatusProps = OwnerStatusProps | 'declined' | 'canceled';
+type BadgeTypeProps = 'user' | 'owner';
 interface BadgeProps {
-  type: 'user' | 'owner';
-  status: 'pending' | 'confirmed' | 'declined' | 'canceled' | 'completed';
+  type: BadgeTypeProps;
+  status: UserStatusProps | OwnerStatusProps;
+  count?: number;
 }
 
-export default function Badge({ type, status }: BadgeProps) {
-  const totalStatus = {
+export default function Badge({ type, status, count }: BadgeProps) {
+  const isOwner = type === 'owner';
+
+  // Owner 일 경우, 미사용 뱃지 검사
+  if (isOwner && ['declined', 'canceled'].includes(status)) {
+    return null;
+  }
+  if (isOwner) {
+    if (['declined', 'canceled'].includes(status)) return null;
+    if (count === 0 || !count) return null;
+  }
+
+  const reservationStatus = {
     user: {
-      pending: '신청 완료',
-      confirmed: '예약 승인',
-      declined: '예약 거절',
-      canceled: '예약 취소',
-      completed: '체험 완료',
+      pending: { label: '신청 완료', style: 'bg-[#DAF0FF] text-[#0D6CD1]' },
+      confirmed: { label: '예약 승인', style: 'bg-[#DDF9F9] text-[#1790A0]' },
+      declined: { label: '예약 거절', style: 'bg-[#FCECEA] text-[#F96767]' },
+      canceled: { label: '예약 취소', style: 'bg-[#E0E0E5] text-[#707177]' },
+      completed: { label: '체험 완료', style: 'bg-[#E9FBE4] text-[#2BA90D]' },
     },
     owner: {
-      pending: '신청 완료',
-      confirmed: '예약 승인',
-      declined: '예약 거절',
+      pending: { label: '예약', style: 'bg-[#E5F3FF] text-[#3D92F2]' },
+      confirmed: { label: '승인', style: 'bg-[#FFF8DD] text-[#FFB051]' },
+      completed: { label: '완료', style: 'bg-[#EDEEF2] text-[#84858C]' },
     },
   };
 
-  let label: string;
-
-  if (type === 'user') {
-    label = totalStatus.user[status];
-  } else {
-    label = totalStatus.owner[status as 'pending' | 'confirmed' | 'declined'];
+  let badgeStatus: { label: string; style: string };
+  switch (type) {
+    case 'user':
+      badgeStatus = reservationStatus.user[status as UserStatusProps];
+      break;
+    case 'owner':
+      badgeStatus = reservationStatus.owner[status as OwnerStatusProps];
+      break;
   }
+  if (!badgeStatus) return null;
+
+  const badgeClass = {
+    user: twMerge('w-63 rounded-full px-6 py-1 text-center text-sm font-bold', badgeStatus.style),
+    owner: twMerge('w-full rounded-sm text-xs md:text-sm font-medium text-center', badgeStatus.style),
+  };
+
   return (
-    <div>
-      <span>{label}</span>
-    </div>
+    <span className={`flex items-center justify-center gap-2 ${badgeClass[type]}`} role='status'>
+      <span>{badgeStatus.label}</span>
+      {isOwner && <span>{count}</span>}
+    </span>
   );
 }

--- a/packages/design-system/src/components/Badge.tsx
+++ b/packages/design-system/src/components/Badge.tsx
@@ -1,0 +1,34 @@
+interface BadgeProps {
+  type: 'user' | 'owner';
+  status: 'pending' | 'confirmed' | 'declined' | 'canceled' | 'completed';
+}
+
+export default function Badge({ type, status }: BadgeProps) {
+  const totalStatus = {
+    user: {
+      pending: '신청 완료',
+      confirmed: '예약 승인',
+      declined: '예약 거절',
+      canceled: '예약 취소',
+      completed: '체험 완료',
+    },
+    owner: {
+      pending: '신청 완료',
+      confirmed: '예약 승인',
+      declined: '예약 거절',
+    },
+  };
+
+  let label: string;
+
+  if (type === 'user') {
+    label = totalStatus.user[status];
+  } else {
+    label = totalStatus.owner[status as 'pending' | 'confirmed' | 'declined'];
+  }
+  return (
+    <div>
+      <span>{label}</span>
+    </div>
+  );
+}

--- a/packages/design-system/src/components/index.ts
+++ b/packages/design-system/src/components/index.ts
@@ -1,3 +1,4 @@
+export { default as Badge } from './Badge';
 export { default as Button } from './Button';
 export { default as ExperienceCard } from './ExperienceCard';
 export * from './icons';

--- a/packages/design-system/src/layouts/Sidebar.tsx
+++ b/packages/design-system/src/layouts/Sidebar.tsx
@@ -21,12 +21,11 @@ export default function DesignSystemLayout() {
 
             <SidebarNavItem label='Calendar' to='/docs/Calendar' />
 
-
-
             <SidebarNavItem label='Textarea' to='/docs/Textarea' />
 
             <SidebarNavItem label='Dropdown' to='/docs/Dropdown' />
             <SidebarNavItem label='ExperienceCard' to='/docs/ExperienceCard' />
+            <SidebarNavItem label='Badge' to='/docs/Badge' />
           </ul>
         </nav>
       </aside>

--- a/packages/design-system/src/pages/BadgeDoc.tsx
+++ b/packages/design-system/src/pages/BadgeDoc.tsx
@@ -1,32 +1,84 @@
+import Badge from '@/components/Badge';
+import DocTemplate, { DocCode } from '@/layouts/DocTemplate';
 import Playground from '@/layouts/Playground';
-
-import Badge from '../components/Badge';
-import DocTemplate, { DocCode } from '../layouts/DocTemplate';
 
 /* Playground는 편집 가능한 코드 블록입니다. */
 /* Playground에서 사용할 예시 코드를 작성해주세요. */
-const code = `예시 코드를 작성해주세요.`;
+const code = `<Badge type='user' status='pending' />`;
 
 export default function BadgeDoc() {
   return (
     <>
       <DocTemplate
         description={`
-# Badge 컴포넌트
+\`Badge\` 컴포넌트는 예약 상태에 따라 시각적으로 정보를 전달하는 역할을 합니다.  
+사용자 유형에 따라 표시 방식이 달라지며, **type**과 **status**에 따라 스타일이 다르게 적용됩니다.
 
-간단한 설명을 작성해주세요.
-`}
+사용자 뱃지(\`user\`)와 제공자 뱃지(\`owner\`)는 각각의 상태별로 스타일이 지정되어 있으며, \`owner\`일 경우 예약 수(count)를 함께 표시할 수 있습니다.
+
+\`\`\`tsx
+import { Badge } from '@what-today/design-system';
+
+<Badge type="user" status="confirmed" />
+<Badge type="owner" status="pending" count={3} />
+\`\`\`
+        `}
         propsDescription={`
-| 이름 | 타입 | 설명 |
-|------|------|------|
-| example | string | 예시 prop입니다. |
-`}
+| Prop    | Type                                                                 | Required | Description                            |
+|---------|----------------------------------------------------------------------|----------|----------------------------------------|
+| type    | "user" \\| "owner"                                                   | Yes      | 사용자 유형 (user: 일반, owner: 제공자) |
+| status  | 예약 상태 타입에 따라 다름 (아래 참고)                               | Yes      | 뱃지 상태 표시                         |
+| count   | number (단, \`type="owner"\`일 경우만 사용)                          | No       | 예약 수 표시 (owner 전용)              |
+
+**Status by type**
+
+| type   | status 목록                                           |
+|--------|--------------------------------------------------------|
+| user   | "pending", "confirmed", "declined", "canceled", "completed" |
+| owner  | "pending", "confirmed", "declined"                     |
+        `}
         title='Badge'
       />
       {/* 실제 컴포넌트를 아래에 작성해주세요 */}
       {/* 예시 코드 */}
-      <DocCode code={`<Badge variant="primary">Click me</Badge>`} />
 
+      <div>
+        <h3 className='mb-8 text-base font-semibold text-gray-600'>user badge</h3>
+        <div className='flex gap-10'>
+          <Badge status='pending' type='user' />
+          <Badge status='confirmed' type='user' />
+          <Badge status='declined' type='user' />
+          <Badge status='canceled' type='user' />
+          <Badge status='completed' type='user' />
+        </div>
+        <DocCode
+          code={`<>
+  <Badge status='pending' type='user' />
+  <Badge status='confirmed' type='user' />
+  <Badge status='declined' type='user' />
+  <Badge status='canceled' type='user' />
+  <Badge status='completed' type='user' />
+</>`}
+          language='tsx'
+        />
+      </div>
+
+      <div className='mt-24'>
+        <h3 className='mb-8 text-base font-semibold text-gray-600'>owner badge - 예약 건수 포함</h3>
+        <div className='flex w-200 gap-10'>
+          <Badge count={3} status='pending' type='owner' />
+          <Badge count={1} status='confirmed' type='owner' />
+          <Badge count={0} status='completed' type='owner' />
+        </div>
+        <DocCode
+          code={`<>
+  <Badge count={3} status='pending' type='owner' />
+  <Badge count={1} status='confirmed' type='owner' />
+  <Badge count={0} status='completed' type='owner' />
+</>`}
+          language='tsx'
+        />
+      </div>
       {/* Playground는 편집 가능한 코드 블록입니다. */}
       <div className='mt-24'>
         <Playground code={code} scope={{ Badge }} />

--- a/packages/design-system/src/pages/BadgeDoc.tsx
+++ b/packages/design-system/src/pages/BadgeDoc.tsx
@@ -1,0 +1,36 @@
+import Playground from '@/layouts/Playground';
+
+import Badge from '../components/Badge';
+import DocTemplate, { DocCode } from '../layouts/DocTemplate';
+
+/* Playground는 편집 가능한 코드 블록입니다. */
+/* Playground에서 사용할 예시 코드를 작성해주세요. */
+const code = `예시 코드를 작성해주세요.`;
+
+export default function BadgeDoc() {
+  return (
+    <>
+      <DocTemplate
+        description={`
+# Badge 컴포넌트
+
+간단한 설명을 작성해주세요.
+`}
+        propsDescription={`
+| 이름 | 타입 | 설명 |
+|------|------|------|
+| example | string | 예시 prop입니다. |
+`}
+        title='Badge'
+      />
+      {/* 실제 컴포넌트를 아래에 작성해주세요 */}
+      {/* 예시 코드 */}
+      <DocCode code={`<Badge variant="primary">Click me</Badge>`} />
+
+      {/* Playground는 편집 가능한 코드 블록입니다. */}
+      <div className='mt-24'>
+        <Playground code={code} scope={{ Badge }} />
+      </div>
+    </>
+  );
+}

--- a/packages/design-system/src/routes/index.tsx
+++ b/packages/design-system/src/routes/index.tsx
@@ -1,3 +1,4 @@
+import BadgeDoc from '@pages/BadgeDoc';
 import ButtonExampleDocs from '@pages/ButtonExampleDocs';
 import CalendarDoc from '@pages/CalendarDoc';
 import DropdownDoc from '@pages/DropdownDoc';
@@ -7,11 +8,8 @@ import InputDoc from '@pages/InputDoc';
 import LandingPage from '@pages/LandingPage';
 import LogoDoc from '@pages/LogoDoc';
 import PaginationDoc from '@pages/PaginationDoc';
-
 import RadioGroupDoc from '@pages/RadioGroupDoc';
-
 import TextareaDoc from '@pages/TextareaDoc';
-
 import { createBrowserRouter, Navigate } from 'react-router-dom';
 
 import Sidebar from '@/layouts/Sidebar';
@@ -32,6 +30,10 @@ const router = createBrowserRouter([
       {
         path: 'button-example',
         element: <ButtonExampleDocs />,
+      },
+      {
+        path: 'Badge',
+        element: <BadgeDoc />,
       },
       {
         path: 'RadioGroup',


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- 이슈 번호 #59 

## 📌 작업 내용
<!-- 해당 PR의 변경 사항을 자세하게 적어주세요.-->
- Badge 컴포넌트 구현
- user, owner 타입으로 구분
- user 타입은 내가 신청한 예약의 상태를 나타내는 뱃지
- owner 타입은 내 체험에 신청된 예약의 상태를 나타내는 뱃지

## ✅ 체크리스트

- [x] PR 하기 전에 이슈에서 빼먹은건 없는지 확인했습니다
  - [x] 라벨 및 마일스톤을 사이드 탭에서 등록했습니다.
- [x] PR을 보내는 브랜치가 올바른지 확인했습니다.
- [x] 팀원들이 리뷰하기 쉽도록 설명을 자세하게 작성했습니다.
- [x] 변경사항을 충분히 테스트 했습니다.
- [x] (함수를 구현 했을 때) JSDoc을 양식에 맞춰서 작성했습니다.
- [x] 컨벤션에 맞게 구현했습니다.

## 📷 UI 변경 사항 (선택)
<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->
<img width="737" height="453" alt="image" src="https://github.com/user-attachments/assets/69f9a4a3-76c9-4bc8-8366-5179c576e8ba" />


## ❓무슨 문제가 발생했나요? (선택)

-

## 💬 기타 참고 사항 (선택)
<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->

-
