### PR TITLE
바텀시트 공통 컴포넌트 구현

### DIFF
--- a/packages/design-system/src/components/bottomsheet/BottomSheetContent.tsx
+++ b/packages/design-system/src/components/bottomsheet/BottomSheetContent.tsx
@@ -1,0 +1,51 @@
+import { useContext } from 'react';
+import { twMerge } from 'tailwind-merge';
+
+import { BottomSheetContext } from './BottomSheetContext';
+import { useDynamicHeight } from './hooks';
+import type { BottomSheetContentProps } from './types';
+
+/**
+ * @component BottomSheet.Content
+ * @description 바텀시트의 콘텐츠 영역을 담당하는 컴포넌트입니다.
+ * 동적 높이 조절과 스크롤 처리를 자동으로 관리합니다.
+ *
+ * @param children - 바텀시트에 표시할 콘텐츠
+ * @param className - 추가적인 스타일을 위한 Tailwind 클래스
+ *
+ * @example
+ * ```tsx
+ * <BottomSheet.Root isOpen={isOpen} onClose={onClose}>
+ *   <BottomSheet.Content>
+ *     <h2>제목</h2>
+ *     <p>내용</p>
+ *   </BottomSheet.Content>
+ * </BottomSheet.Root>
+ * ```
+ */
+export function BottomSheetContent({ children, className }: BottomSheetContentProps) {
+  const context = useContext(BottomSheetContext);
+
+  if (!context) {
+    throw new Error('BottomSheetContent는 BottomSheet.Root 안에서 사용되어야 합니다.');
+  }
+
+  const { isOpen, contentRef } = context;
+
+  // 동적 높이 조절
+  const { contentHeight, isScrollable } = useDynamicHeight(contentRef, isOpen);
+
+  return (
+    <div
+      ref={contentRef}
+      className={twMerge('px-4 pb-4', className)}
+      style={{
+        height: contentHeight ? `${contentHeight}px` : 'auto',
+        overflowY: isScrollable ? 'auto' : 'visible',
+        maxHeight: contentHeight ? `${contentHeight}px` : 'none',
+      }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/packages/design-system/src/components/bottomsheet/BottomSheetContent.tsx
+++ b/packages/design-system/src/components/bottomsheet/BottomSheetContent.tsx
@@ -38,7 +38,7 @@ export function BottomSheetContent({ children, className }: BottomSheetContentPr
   return (
     <div
       ref={contentRef}
-      className={twMerge('px-4 pb-4', className)}
+      className={twMerge('px-16 pb-16', className)}
       style={{
         height: contentHeight ? `${contentHeight}px` : 'auto',
         overflowY: isScrollable ? 'auto' : 'visible',

--- a/packages/design-system/src/components/bottomsheet/BottomSheetContext.tsx
+++ b/packages/design-system/src/components/bottomsheet/BottomSheetContext.tsx
@@ -1,0 +1,11 @@
+import { createContext, useContext } from 'react';
+
+import type { BottomSheetContextType } from './types';
+
+export const BottomSheetContext = createContext<BottomSheetContextType | null>(null);
+
+export function useBottomSheetContext() {
+  const context = useContext(BottomSheetContext);
+  if (!context) throw new Error('BottomSheet 내부에서만 사용 가능합니다.');
+  return context;
+}

--- a/packages/design-system/src/components/bottomsheet/BottomSheetHeader.tsx
+++ b/packages/design-system/src/components/bottomsheet/BottomSheetHeader.tsx
@@ -1,0 +1,26 @@
+import { twMerge } from 'tailwind-merge';
+
+import type { BottomSheetHeaderProps } from './types';
+
+/**
+ * @component BottomSheet.Header
+ * @description
+ * 바텀시트 상단에 위치한 iOS 스타일의 핸들을 표시합니다.
+ * 사용자가 드래그할 수 있는 영역으로, 상단 여백과 함께 시각적 힌트를 제공합니다.
+ * 헤더 영역에서의 드래그는 콘텐츠 스크롤 위치와 관계없이 바텀시트를 닫을 수 있습니다.
+ *
+ * @param className - 추가적인 스타일을 위한 Tailwind 클래스
+ *
+ * @example
+ * ```tsx
+ * <BottomSheet.Header />
+ * ```
+ */
+
+export function BottomSheetHeader({ className }: BottomSheetHeaderProps) {
+  return (
+    <div className={twMerge('relative h-24 rounded-t-2xl pt-12 pb-4', className)} data-bottomsheet-header='true'>
+      <div className='mx-auto h-4 w-40 rounded bg-gray-300' />
+    </div>
+  );
+}

--- a/packages/design-system/src/components/bottomsheet/BottomSheetOverlay.tsx
+++ b/packages/design-system/src/components/bottomsheet/BottomSheetOverlay.tsx
@@ -1,0 +1,13 @@
+import { twMerge } from 'tailwind-merge';
+
+import type { BottomSheetOverlayProps } from './types';
+
+/**
+ * @component BottomSheetOverlay
+ * @description 바텀시트 배경 오버레이입니다. 클릭하면 바텀시트가 닫힙니다.
+ */
+export function BottomSheetOverlay({ onClick, className }: BottomSheetOverlayProps) {
+  return (
+    <div className={twMerge('fixed inset-0 z-40 bg-black/5 backdrop-brightness-50', className)} onClick={onClick} />
+  );
+}

--- a/packages/design-system/src/components/bottomsheet/BottomSheetRoot.tsx
+++ b/packages/design-system/src/components/bottomsheet/BottomSheetRoot.tsx
@@ -1,0 +1,54 @@
+import { useRef } from 'react';
+import { twMerge } from 'tailwind-merge';
+
+import { Portal } from '../Portal';
+import { BottomSheetContext } from './BottomSheetContext';
+import { BottomSheetHeader } from './BottomSheetHeader';
+import { BottomSheetOverlay } from './BottomSheetOverlay';
+import { useBodyScrollLock, useDragToClose } from './hooks';
+import type { BottomSheetRootProps } from './types';
+
+/**
+ * @component BottomSheet.Root
+ * @description Portal을 사용한 바텀시트 기본 구조를 제공합니다.
+ * 배경 스크롤이 방지되고 헤더와 콘텐츠 영역을 구분하여 스마트하게 드래그로 닫을 수 있습니다.
+ * 동적 높이 조절은 BottomSheet.Content 컴포넌트에서 담당합니다.
+ */
+export function BottomSheetRoot({ isOpen, onClose, children, className }: BottomSheetRootProps) {
+  const sheetRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  // 바텀시트가 열릴 때 배경 스크롤 방지
+  useBodyScrollLock(isOpen);
+
+  // 드래그로 닫기 기능 (스크롤 위치 고려)
+  const { dragHandlers } = useDragToClose(sheetRef, contentRef, onClose, isOpen);
+
+  return (
+    <BottomSheetContext.Provider value={{ isOpen, onClose, sheetRef, contentRef }}>
+      <Portal>
+        <BottomSheetOverlay
+          className={twMerge(
+            'transition-opacity duration-300',
+            isOpen ? 'opacity-100' : 'pointer-events-none opacity-0',
+          )}
+          onClick={onClose}
+        />
+
+        <div
+          ref={sheetRef}
+          className={twMerge(
+            'fixed right-0 bottom-0 left-0 z-50 flex flex-col rounded-t-2xl bg-white',
+            'transition-transform duration-300 ease-out',
+            isOpen ? 'translate-y-0' : 'translate-y-full',
+            className,
+          )}
+          {...dragHandlers}
+        >
+          <BottomSheetHeader />
+          {children}
+        </div>
+      </Portal>
+    </BottomSheetContext.Provider>
+  );
+}

--- a/packages/design-system/src/components/bottomsheet/hooks/index.ts
+++ b/packages/design-system/src/components/bottomsheet/hooks/index.ts
@@ -1,0 +1,171 @@
+import { useEffect, useRef } from 'react';
+
+import type { BottomSheetMetrics } from '../types';
+
+// 바텀시트가 최대로 올라 갔을 때의 Y좌표 값
+const MIN_Y = 60;
+// 바텀시트가 최대로 내려갔을 때의 Y좌표 값 (초기값은 window 기준)
+const MAX_Y = typeof window !== 'undefined' ? window.innerHeight - 100 : 800;
+
+export function useBottomSheet() {
+  const sheetRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  const metrics = useRef<BottomSheetMetrics>({
+    touchStart: {
+      sheetY: 0,
+      touchY: 0,
+    },
+    touchMove: {
+      prevTouchY: 0,
+      movingDirection: 'none',
+    },
+    isContentAreaTouched: false,
+  });
+
+  // 바텀시트 드래그 동작 제어
+  useEffect(() => {
+    // 콘텐츠 스크롤 여부와 드래그 방향에 따라 바텀시트 이동 가능 여부 결정
+    const canUserMoveSheet = () => {
+      const { isContentAreaTouched, touchMove } = metrics.current;
+
+      // 바텀시트에서 컨텐츠 영역이 아닌 부분을 터치하면 바텀시트를 이동합니다.
+      if (!isContentAreaTouched) {
+        return true;
+      }
+
+      // 바텀 시트가 최대로 올라와 있는 상태가 아니라면 바텀 시트는 움직일 수 있습니다.
+      if (sheetRef.current!.getBoundingClientRect().y !== MIN_Y) {
+        return true;
+      }
+
+      // 드래그(터치) 하는 상태에서 아래로 스크롤 했을 때 더 이상 스크롤이 불가능한 경우 바텀시트를 내립니다.
+      if (touchMove.movingDirection === 'down') {
+        return contentRef.current!.scrollTop <= 0;
+      }
+
+      // 위의 내용에 해당하지 않는 경우 바텀시트는 움직이지 않습니다.
+      return false;
+    };
+
+    // 드래그(터치) 시작 시 불려지는 함수
+    const handleTouchStart = (e: TouchEvent) => {
+      // metrics 객체로부터 touchStart 정보를 가져옵니다.
+      const { touchStart } = metrics.current;
+
+      // 현재 바텀시트의 최상단 Y 좌표를 가져와 touchStart에 저장합니다.
+      touchStart.sheetY = sheetRef.current!.getBoundingClientRect().y;
+      // 터치한 위치의 Y 좌표를 touchStart에 저장합니다.
+      touchStart.touchY = e.touches[0].clientY;
+    };
+
+    // 드래그(터치)를 유지한 채로 이동할 때 불려지는 함수
+    const handleTouchMove = (e: TouchEvent) => {
+      // metrics 객체로부터 touchStart와 touchMove 정보를 가져옵니다.
+      const { touchStart, touchMove } = metrics.current;
+      // 현재 터치 위치를 가져옵니다.
+      const currentTouch = e.touches[0];
+
+      // 이전 프레임의 터치 위치가 없을 경우, 터치 시작 위치를 초기값으로 설정합니다.
+      if (touchMove.prevTouchY === undefined || touchMove.prevTouchY === 0) {
+        touchMove.prevTouchY = touchStart.touchY;
+      }
+
+      // 이전 터치 위치와 현재 터치 위치를 비교하여 이동 방향을 결정합니다.
+      touchMove.movingDirection = touchMove.prevTouchY < currentTouch.clientY ? 'down' : 'up';
+
+      // 바텀시트를 움직일 수 있을 경우
+      if (canUserMoveSheet()) {
+        // 브라우저 기본 동작 방지
+        e.preventDefault();
+
+        // 손가락이 움직인 거리 = 현재 터치 위치 - 터치 시작 위치
+        const offset = currentTouch.clientY - touchStart.touchY;
+        // 바텀시트의 다음 위치를 계산: 시작 위치 + 이동 거리
+        let nextY = touchStart.sheetY + offset;
+
+        // 바텀시트의 높이는 최소 MIN_Y와 최대 MAX_Y 사이로 제한합니다.
+        if (nextY < MIN_Y) {
+          nextY = MIN_Y;
+        }
+        if (nextY > MAX_Y) {
+          nextY = MAX_Y;
+        }
+
+        // 바텀시트의 실제 위치를 변경하는 부분
+        // nextY는 화면 기준 Y 좌표이며, translateY는 기준점이 0이므로
+        // 바닥 위치(MAX_Y)에서 상대 이동거리만큼 빼서 translateY로 적용
+        // 즉: translateY는 시트를 "아래로 얼마나 이동할지"를 지정하는 값이므로
+        // 화면 상의 위치 Y (nextY) - 최대 Y (MAX_Y) = 실제 이동 거리
+        sheetRef.current!.style.transform = `translateY(${nextY - MAX_Y}px)`;
+      } else {
+        // 컨텐츠를 스크롤하는 동안에는 body가 스크롤 되는 것을 막는다.
+        document.body.style.overflowY = 'hidden';
+      }
+    };
+
+    // 드래그(터치) 종료 시 불려지는 함수
+    const handleTouchEnd = () => {
+      // 콘텐츠가 스크롤 가능하도록 다시 body의 스크롤을 복구
+      document.body.style.overflowY = 'auto';
+
+      // 사용자가 손가락을 위로 뗐는지, 아래로 뗐는지 방향 정보 가져오기
+      const { movingDirection } = metrics.current.touchMove;
+
+      // 드래그(터치)가 끝난 후 바텀시트의 최상단 모서리 Y 좌표를 가져옵니다.
+      const currentY = sheetRef.current!.getBoundingClientRect().y;
+
+      // 바텀시트가 최대로 올라간 상태가 아니라면, 드래그 방향에 따라 바텀시트를 올리거나 내립니다.
+      if (currentY !== MIN_Y) {
+        // 아래로 스크롤 하는 경우 바텀시트가 가장 작은 크기로 축소됩니다.(원래 크기)
+        if (movingDirection === 'down') {
+          sheetRef.current!.style.transform = 'translateY(0)';
+        } else if (movingDirection === 'up') {
+          // 위로 스크롤 하는 경우 바텀시트가 최대로 올라갑니다.
+          sheetRef.current!.style.transform = `translateY(${MIN_Y - MAX_Y}px)`;
+        }
+      }
+
+      // 드래그(터치)에 사용된 내부 상태값 초기화
+      metrics.current = {
+        touchStart: {
+          sheetY: 0,
+          touchY: 0,
+        },
+        touchMove: {
+          prevTouchY: 0,
+          movingDirection: 'none',
+        },
+        isContentAreaTouched: false,
+      };
+    };
+
+    // sheet 요소 참조를 가져와 이벤트 리스너를 등록합니다.
+    const sheetEl = sheetRef.current;
+    // sheetEl이 존재하지 않으면 이벤트 리스너를 등록하지 않습니다. (예: 컴포넌트가 마운트되지 않은 경우)
+    if (!sheetEl) return;
+
+    // 바텀시트에 터치 이벤트 리스너 등록
+    sheetEl.addEventListener('touchstart', handleTouchStart); // 터치 시작 시 로직 실행
+    sheetEl.addEventListener('touchmove', handleTouchMove); // 터치 이동 중 로직 실행
+    sheetEl.addEventListener('touchend', handleTouchEnd); // 터치 종료 시 로직 실행
+
+    // 컴포넌트 언마운트 시 또는 리렌더링 시 이전 이벤트 리스너 정리(clean-up)
+    return () => {
+      sheetEl.removeEventListener('touchstart', handleTouchStart);
+      sheetEl.removeEventListener('touchmove', handleTouchMove);
+      sheetEl.removeEventListener('touchend', handleTouchEnd);
+    };
+  }, []);
+
+  // 콘텐츠 영역에서 터치 시작 여부 추적
+  useEffect(() => {
+    const handleTouchStart = () => {
+      metrics.current.isContentAreaTouched = true;
+    };
+    contentRef.current?.addEventListener('touchstart', handleTouchStart);
+  }, []);
+
+  // 바텀시트 wrapper와 content 영역 ref 반환
+  return { sheetRef, contentRef };
+}

--- a/packages/design-system/src/components/bottomsheet/index.ts
+++ b/packages/design-system/src/components/bottomsheet/index.ts
@@ -1,0 +1,9 @@
+import { BottomSheetContent } from './BottomSheetContent';
+import { BottomSheetHeader } from './BottomSheetHeader';
+import { BottomSheetRoot } from './BottomSheetRoot';
+
+export const BottomSheet = {
+  Root: BottomSheetRoot,
+  Header: BottomSheetHeader,
+  Content: BottomSheetContent,
+};

--- a/packages/design-system/src/components/bottomsheet/types/index.ts
+++ b/packages/design-system/src/components/bottomsheet/types/index.ts
@@ -4,38 +4,37 @@ export interface BottomSheetContextType {
   /** BottomSheet의 열림 상태를 제어하는 함수 */
   onClose: () => void;
   /** BottomSheet의 전체(wrapper) 요소에 대한 ref */
-  sheetRef: React.RefObject<HTMLDivElement>;
+  sheetRef: React.RefObject<HTMLDivElement | null>;
   /** BottomSheet의 내부 콘텐츠(scroll 영역)에 대한 ref */
-  contentRef: React.RefObject<HTMLDivElement>;
+  contentRef: React.RefObject<HTMLDivElement | null>;
 }
 
-/**
- * 바텀시트 드래그 동작 시 내부에서 관리되는 상태 인터페이스
- */
-export interface BottomSheetMetrics {
-  /**
-   * 드래그(터치) 시작 시점의 위치 정보
-   * - sheetY: 바텀시트 최상단의 Y 좌표 (getBoundingClientRect 기준)
-   * - touchY: 사용자가 화면을 터치한 Y 좌표
-   */
-  touchStart: {
-    sheetY: number;
-    touchY: number;
-  };
+export interface BottomSheetRootProps {
+  /** BottomSheet의 열림 상태 */
+  isOpen: boolean;
+  /** BottomSheet의 열림 상태를 제어하는 함수 */
+  onClose: () => void;
+  /** BottomSheet 내부 children */
+  children: React.ReactNode;
+  /** Tailwind CSS 클래스 */
+  className?: string;
+}
 
-  /**
-   * 드래그(터치) 중 계산되는 정보
-   * - prevTouchY: 이전 프레임의 터치 위치 (이동 방향 계산용)
-   * - movingDirection: 사용자가 손가락을 위로/아래로 움직이는지 방향 정보
-   */
-  touchMove: {
-    prevTouchY?: number;
-    movingDirection: 'none' | 'up' | 'down';
-  };
+export interface BottomSheetHeaderProps {
+  /** 추가적인 스타일을 위한 Tailwind 클래스 */
+  className?: string;
+}
 
-  /**
-   * 콘텐츠 영역에서 터치가 시작되었는지 여부
-   * → 콘텐츠가 스크롤 가능한 영역인지 판단하는 기준
-   */
-  isContentAreaTouched: boolean;
+export interface BottomSheetContentProps {
+  /** 바텀시트에 표시할 콘텐츠 */
+  children: React.ReactNode;
+  /** 추가적인 스타일을 위한 Tailwind 클래스 */
+  className?: string;
+}
+
+export interface BottomSheetOverlayProps {
+  /** 오버레이 클릭 시 실행되는 함수 */
+  onClick: () => void;
+  /** Tailwind CSS 클래스 */
+  className?: string;
 }

--- a/packages/design-system/src/components/bottomsheet/types/index.ts
+++ b/packages/design-system/src/components/bottomsheet/types/index.ts
@@ -8,3 +8,34 @@ export interface BottomSheetContextType {
   /** BottomSheet의 내부 콘텐츠(scroll 영역)에 대한 ref */
   contentRef: React.RefObject<HTMLDivElement>;
 }
+
+/**
+ * 바텀시트 드래그 동작 시 내부에서 관리되는 상태 인터페이스
+ */
+export interface BottomSheetMetrics {
+  /**
+   * 드래그(터치) 시작 시점의 위치 정보
+   * - sheetY: 바텀시트 최상단의 Y 좌표 (getBoundingClientRect 기준)
+   * - touchY: 사용자가 화면을 터치한 Y 좌표
+   */
+  touchStart: {
+    sheetY: number;
+    touchY: number;
+  };
+
+  /**
+   * 드래그(터치) 중 계산되는 정보
+   * - prevTouchY: 이전 프레임의 터치 위치 (이동 방향 계산용)
+   * - movingDirection: 사용자가 손가락을 위로/아래로 움직이는지 방향 정보
+   */
+  touchMove: {
+    prevTouchY?: number;
+    movingDirection: 'none' | 'up' | 'down';
+  };
+
+  /**
+   * 콘텐츠 영역에서 터치가 시작되었는지 여부
+   * → 콘텐츠가 스크롤 가능한 영역인지 판단하는 기준
+   */
+  isContentAreaTouched: boolean;
+}

--- a/packages/design-system/src/components/bottomsheet/types/index.ts
+++ b/packages/design-system/src/components/bottomsheet/types/index.ts
@@ -1,0 +1,10 @@
+export interface BottomSheetContextType {
+  /** BottomSheet가 열려 있는지 상태 여부 */
+  isOpen: boolean;
+  /** BottomSheet의 열림 상태를 제어하는 함수 */
+  onClose: () => void;
+  /** BottomSheet의 전체(wrapper) 요소에 대한 ref */
+  sheetRef: React.RefObject<HTMLDivElement>;
+  /** BottomSheet의 내부 콘텐츠(scroll 영역)에 대한 ref */
+  contentRef: React.RefObject<HTMLDivElement>;
+}

--- a/packages/design-system/src/layouts/Sidebar.tsx
+++ b/packages/design-system/src/layouts/Sidebar.tsx
@@ -30,6 +30,7 @@ export default function DesignSystemLayout() {
             <SidebarNavItem label='ReservationCard' to='/docs/ReservationCard' />
             <SidebarNavItem label='OwnerBadge' to='/docs/OwnerBadge' />
             <SidebarNavItem label='Toast' to='/docs/Toast' />
+            <SidebarNavItem label='BottomSheet' to='/docs/BottomSheet' />
           </ul>
         </nav>
       </aside>

--- a/packages/design-system/src/pages/BottomSheetDoc.tsx
+++ b/packages/design-system/src/pages/BottomSheetDoc.tsx
@@ -1,25 +1,229 @@
 import { useState } from 'react';
 
-import Playground from '@/layouts/Playground';
-
 import { BottomSheet } from '../components/bottomsheet';
 import DocTemplate, { DocCode } from '../layouts/DocTemplate';
 
-/* Playground는 편집 가능한 코드 블록입니다. */
-/* Playground에서 사용할 예시 코드를 작성해주세요. */
-const code = `
-// 테스트는 위에 Example 버튼을 눌러서 해주세요.
+// 다단계 바텀시트 예시 코드
+const multiStepCode = `function MultiStepBottomSheetExample() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [currentStep, setCurrentStep] = useState('datetime'); // 'datetime' | 'people'
+  const [selectedData, setSelectedData] = useState({
+    date: '2024/11/14',
+    time: '14:00-15:00',
+    people: 1
+  });
 
-<BottomSheet.Root isOpen={isOpen} onClose={onClose}>
-  <BottomSheet.Content>
-    <h2>제목</h2>
-    <p>역할이 명확히 분리된 완전한 바텀시트!</p>
-  </BottomSheet.Content>
-</BottomSheet.Root>`;
+  // 바텀시트 닫기 (초기화)
+  const handleClose = () => {
+    setIsOpen(false);
+    setCurrentStep('datetime');
+  };
+
+  // 1단계: 날짜/시간 선택 → 인원 선택으로 이동
+  const handleDateTimeConfirm = (date, time) => {
+    setSelectedData(prev => ({ ...prev, date, time }));
+    setCurrentStep('people'); // 2단계로 이동
+  };
+
+  // 2단계: 인원 선택 → 최종 확인
+  const handlePeopleConfirm = (people) => {
+    setSelectedData(prev => ({ ...prev, people }));
+    setIsOpen(false); // 바텀시트 닫기
+    setCurrentStep('datetime'); // 초기화
+    console.log('최종 선택:', { ...selectedData, people });
+  };
+
+  // 2단계에서 1단계로 돌아가기
+  const handleBackToDateTime = () => {
+    setCurrentStep('datetime');
+  };
+
+  return (
+    <>
+      <button onClick={() => setIsOpen(true)}>
+        예약하기 ({selectedData.date} {selectedData.time} {selectedData.people}명)
+      </button>
+
+      <BottomSheet.Root isOpen={isOpen} onClose={handleClose}>
+        {currentStep === 'datetime' && (
+          <BottomSheet.Content>
+            <h2 className="text-lg font-bold mb-4">날짜 및 시간 선택</h2>
+            {/* 달력과 시간 선택 UI */}
+            <div className="space-y-4 mb-6">
+              <div>선택된 날짜: {selectedData.date}</div>
+              <div>선택된 시간: {selectedData.time}</div>
+            </div>
+            <button 
+              className="w-full px-4 py-3 bg-blue-500 text-white rounded"
+              onClick={() => handleDateTimeConfirm(selectedData.date, selectedData.time)}
+            >
+              확인
+            </button>
+          </BottomSheet.Content>
+        )}
+
+        {currentStep === 'people' && (
+          <BottomSheet.Content>
+            <div className="flex items-center mb-4">
+              <button 
+                className="p-2 mr-3 text-gray-600"
+                onClick={handleBackToDateTime}
+              >
+                ← 뒤로
+              </button>
+              <h2 className="text-lg font-bold">인원 선택</h2>
+            </div>
+            
+            <div className="space-y-4 mb-6">
+              <div>예약 정보:</div>
+              <div className="text-sm text-gray-600">
+                {selectedData.date} {selectedData.time}
+              </div>
+              
+              <div className="flex items-center justify-between">
+                <span>인원 수</span>
+                <div className="flex items-center space-x-3">
+                  <button 
+                    className="w-8 h-8 rounded border"
+                    onClick={() => setSelectedData(prev => ({ 
+                      ...prev, 
+                      people: Math.max(1, prev.people - 1) 
+                    }))}
+                  >
+                    -
+                  </button>
+                  <span className="w-8 text-center">{selectedData.people}</span>
+                  <button 
+                    className="w-8 h-8 rounded border"
+                    onClick={() => setSelectedData(prev => ({ 
+                      ...prev, 
+                      people: prev.people + 1 
+                    }))}
+                  >
+                    +
+                  </button>
+                </div>
+              </div>
+            </div>
+            
+            <button 
+              className="w-full px-4 py-3 bg-blue-500 text-white rounded"
+              onClick={() => handlePeopleConfirm(selectedData.people)}
+            >
+              예약하기
+            </button>
+          </BottomSheet.Content>
+        )}
+      </BottomSheet.Root>
+    </>
+  );
+}`;
+
+// 애니메이션 다단계 바텀시트 예시 코드
+const animatedMultiStepCode = `function AnimatedMultiStepBottomSheet() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [currentStep, setCurrentStep] = useState('datetime');
+  const [selectedData, setSelectedData] = useState({
+    date: '2024/11/14',
+    time: '14:00-15:00',
+    people: 1
+  });
+  const [isTransitioning, setIsTransitioning] = useState(false);
+
+  const handleClose = () => {
+    setIsOpen(false);
+    setCurrentStep('datetime');
+    setIsTransitioning(false);
+  };
+
+  // 🎬 애니메이션 전환: 닫기 → 잠깐 대기 → 다시 열기
+  const handleAnimatedDateTimeConfirm = () => {
+    if (isTransitioning) return;
+    
+    setIsTransitioning(true);
+    setIsOpen(false); // 1. 바텀시트 닫기 애니메이션
+    
+    setTimeout(() => { // 2. 애니메이션 완료까지 대기 (0.3s)
+      setCurrentStep('people'); // 3. 다음 단계로 변경
+      setIsOpen(true); // 4. 바텀시트 다시 열기 애니메이션
+      setIsTransitioning(false);
+    }, 300); // CSS transition 시간과 맞춤
+  };
+
+  const handleAnimatedBackToDateTime = () => {
+    if (isTransitioning) return;
+    
+    setIsTransitioning(true);
+    setIsOpen(false); // 닫기
+    
+    setTimeout(() => {
+      setCurrentStep('datetime'); // 이전 단계
+      setIsOpen(true); // 다시 열기
+      setIsTransitioning(false);
+    }, 300);
+  };
+
+  return (
+    <>
+      <button onClick={() => setIsOpen(true)}>
+        ✨ 애니메이션 예약하기
+      </button>
+
+      <BottomSheet.Root isOpen={isOpen} onClose={handleClose}>
+        {currentStep === 'datetime' && (
+          <BottomSheet.Content>
+            <h2>✨ 날짜/시간 선택 (애니메이션)</h2>
+            <button 
+              className="w-full bg-pink-500 text-white rounded"
+              onClick={handleAnimatedDateTimeConfirm}
+              disabled={isTransitioning}
+            >
+              {isTransitioning ? '전환 중...' : '확인 (애니메이션 전환)'}
+            </button>
+          </BottomSheet.Content>
+        )}
+
+        {currentStep === 'people' && (
+          <BottomSheet.Content>
+            <button 
+              onClick={handleAnimatedBackToDateTime}
+              disabled={isTransitioning}
+            >
+              ← 뒤로 (애니메이션)
+            </button>
+            <h2>✨ 인원 선택 (애니메이션)</h2>
+            {/* 나머지 UI */}
+          </BottomSheet.Content>
+        )}
+      </BottomSheet.Root>
+    </>
+  );
+}`;
 
 export default function BottomSheetDoc() {
   const [isOpen, setIsOpen] = useState(false);
-  const [contentType, setContentType] = useState<'short' | 'medium' | 'long'>('short');
+  const [contentType, setContentType] = useState<'short' | 'medium' | 'long' | 'multistep' | 'animated-multistep'>(
+    'short',
+  );
+
+  // 다단계 바텀시트 상태
+  const [multiStepOpen, setMultiStepOpen] = useState(false);
+  const [currentStep, setCurrentStep] = useState<'datetime' | 'people'>('datetime');
+  const [selectedData, setSelectedData] = useState({
+    date: '2024/11/14',
+    time: '14:00-15:00',
+    people: 1,
+  });
+
+  // 애니메이션 다단계 바텀시트 상태
+  const [animatedMultiStepOpen, setAnimatedMultiStepOpen] = useState(false);
+  const [animatedCurrentStep, setAnimatedCurrentStep] = useState<'datetime' | 'people'>('datetime');
+  const [animatedSelectedData, setAnimatedSelectedData] = useState({
+    date: '2024/11/14',
+    time: '14:00-15:00',
+    people: 1,
+  });
+  const [isTransitioning, setIsTransitioning] = useState(false);
 
   const shortContent = (
     <BottomSheet.Content>
@@ -107,34 +311,394 @@ export default function BottomSheetDoc() {
     </BottomSheet.Content>
   );
 
-  const handleOpenBottomSheet = (type: 'short' | 'medium' | 'long') => {
-    setContentType(type);
-    setIsOpen(true);
+  const handleOpenBottomSheet = (type: 'short' | 'medium' | 'long' | 'multistep' | 'animated-multistep') => {
+    if (type === 'multistep') {
+      setMultiStepOpen(true);
+      setCurrentStep('datetime');
+    } else if (type === 'animated-multistep') {
+      setAnimatedMultiStepOpen(true);
+      setAnimatedCurrentStep('datetime');
+    } else {
+      setContentType(type);
+      setIsOpen(true);
+    }
+  };
+
+  // 다단계 바텀시트 핸들러들
+  const handleMultiStepClose = () => {
+    setMultiStepOpen(false);
+    setCurrentStep('datetime');
+  };
+
+  const handleDateTimeConfirm = () => {
+    setCurrentStep('people');
+  };
+
+  const handlePeopleConfirm = () => {
+    setMultiStepOpen(false);
+    setCurrentStep('datetime');
+    alert(`예약 완료: ${selectedData.date} ${selectedData.time} ${selectedData.people}명`);
+  };
+
+  const handleBackToDateTime = () => {
+    setCurrentStep('datetime');
+  };
+
+  // 애니메이션 다단계 바텀시트 핸들러들
+  const handleAnimatedMultiStepClose = () => {
+    setAnimatedMultiStepOpen(false);
+    setAnimatedCurrentStep('datetime');
+    setIsTransitioning(false);
+  };
+
+  const handleAnimatedDateTimeConfirm = () => {
+    if (isTransitioning) return; // 전환 중이면 무시
+
+    setIsTransitioning(true);
+    // 1. 바텀시트 닫기
+    setAnimatedMultiStepOpen(false);
+
+    // 2. 애니메이션 완료 후 다음 단계로 이동
+    setTimeout(() => {
+      setAnimatedCurrentStep('people');
+      setAnimatedMultiStepOpen(true);
+      setIsTransitioning(false);
+    }, 300); // CSS 애니메이션 시간과 맞춤 (0.3s)
+  };
+
+  const handleAnimatedPeopleConfirm = () => {
+    setAnimatedMultiStepOpen(false);
+    setAnimatedCurrentStep('datetime');
+    setIsTransitioning(false);
+    alert(`예약 완료: ${animatedSelectedData.date} ${animatedSelectedData.time} ${animatedSelectedData.people}명`);
+  };
+
+  const handleAnimatedBackToDateTime = () => {
+    if (isTransitioning) return; // 전환 중이면 무시
+
+    setIsTransitioning(true);
+    // 1. 바텀시트 닫기
+    setAnimatedMultiStepOpen(false);
+
+    // 2. 애니메이션 완료 후 이전 단계로 이동
+    setTimeout(() => {
+      setAnimatedCurrentStep('datetime');
+      setAnimatedMultiStepOpen(true);
+      setIsTransitioning(false);
+    }, 300); // CSS 애니메이션 시간과 맞춤 (0.3s)
   };
 
   return (
     <>
+      <div className='mb-4 flex flex-col gap-2'>
+        <button
+          className='rounded bg-green-500 px-4 py-2 text-white hover:bg-green-600'
+          onClick={() => handleOpenBottomSheet('short')}
+        >
+          짧은 콘텐츠
+        </button>
+        <button
+          className='rounded bg-blue-500 px-4 py-2 text-white hover:bg-blue-600'
+          onClick={() => handleOpenBottomSheet('medium')}
+        >
+          중간 콘텐츠
+        </button>
+        <button
+          className='rounded bg-purple-500 px-4 py-2 text-white hover:bg-purple-600'
+          onClick={() => handleOpenBottomSheet('long')}
+        >
+          긴 콘텐츠 (🎯 헤더 + 스마트 드래그)
+        </button>
+        <button
+          className='rounded bg-orange-500 px-4 py-2 text-white hover:bg-orange-600'
+          onClick={() => handleOpenBottomSheet('multistep')}
+        >
+          🔄 다단계 바텀시트
+        </button>
+        <button
+          className='rounded bg-pink-500 px-4 py-2 text-white hover:bg-pink-600'
+          onClick={() => handleOpenBottomSheet('animated-multistep')}
+        >
+          ✨ 애니메이션 다단계 바텀시트
+        </button>
+      </div>
+
+      {/* 스크롤 테스트를 위한 긴 콘텐츠 */}
+      <div className='mb-8'>
+        <h3 className='mb-4 text-lg font-bold'>다단계 바텀시트 테스트 설명</h3>
+        <div className='space-y-4'>
+          <div className='rounded bg-green-50 p-4'>
+            <h4 className='font-semibold text-green-800'>🟢 기본 바텀시트</h4>
+            <p className='text-green-700'>단일 콘텐츠로 구성된 기본 바텀시트</p>
+          </div>
+          <div className='rounded bg-orange-50 p-4'>
+            <h4 className='font-semibold text-orange-800'>🔄 다단계 바텀시트 (일반)</h4>
+            <div className='space-y-2 text-orange-700'>
+              <p>
+                <strong>1단계</strong>: 날짜/시간 선택 → 확인 버튼
+              </p>
+              <p>
+                <strong>2단계</strong>: 인원 선택 (뒤로가기 + 최종 확인)
+              </p>
+              <p className='text-sm'>
+                <strong>구현 방식</strong>: 사용자 상태 관리 (currentStep state)
+              </p>
+              <p className='text-sm'>
+                <strong>애니메이션</strong>: 콘텐츠만 교체 (바텀시트 유지)
+              </p>
+            </div>
+          </div>
+          <div className='rounded bg-pink-50 p-4'>
+            <h4 className='font-semibold text-pink-800'>✨ 애니메이션 다단계 바텀시트</h4>
+            <div className='space-y-2 text-pink-700'>
+              <p>
+                <strong>1단계</strong>: 날짜/시간 선택 → 확인 버튼
+              </p>
+              <p>
+                <strong>2단계</strong>: 인원 선택 (뒤로가기 + 최종 확인)
+              </p>
+              <p className='text-sm'>
+                <strong>구현 방식</strong>: 바텀시트 닫기 → 잠깐 대기 → 다시 열기
+              </p>
+              <p className='text-sm'>
+                <strong>애니메이션</strong>: 내려갔다가 올라오는 부드러운 전환 ✨
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* 기본 바텀시트 */}
       <BottomSheet.Root isOpen={isOpen} onClose={() => setIsOpen(false)}>
         {contentType === 'short' && shortContent}
         {contentType === 'medium' && mediumContent}
         {contentType === 'long' && longContent}
       </BottomSheet.Root>
 
+      {/* 다단계 바텀시트 */}
+      <BottomSheet.Root isOpen={multiStepOpen} onClose={handleMultiStepClose}>
+        {currentStep === 'datetime' && (
+          <BottomSheet.Content>
+            <h2 className='mb-4 text-lg font-bold'>📅 날짜 및 시간 선택</h2>
+            <div className='mb-6 space-y-4'>
+              <div className='rounded bg-blue-50 p-3'>
+                <div className='text-sm text-gray-600'>선택된 날짜</div>
+                <div className='font-semibold'>{selectedData.date}</div>
+              </div>
+              <div className='rounded bg-blue-50 p-3'>
+                <div className='text-sm text-gray-600'>선택된 시간</div>
+                <div className='font-semibold'>{selectedData.time}</div>
+              </div>
+            </div>
+            <button className='w-full rounded bg-blue-500 px-4 py-3 text-white' onClick={handleDateTimeConfirm}>
+              확인 (다음 단계)
+            </button>
+          </BottomSheet.Content>
+        )}
+
+        {currentStep === 'people' && (
+          <BottomSheet.Content>
+            <div className='mb-4 flex items-center'>
+              <button className='mr-3 rounded p-2 text-gray-600 hover:bg-gray-100' onClick={handleBackToDateTime}>
+                ← 뒤로
+              </button>
+              <h2 className='text-lg font-bold'>👥 인원 선택</h2>
+            </div>
+
+            <div className='mb-6 space-y-4'>
+              <div className='rounded bg-gray-50 p-3'>
+                <div className='text-sm text-gray-600'>예약 정보</div>
+                <div className='font-semibold'>
+                  {selectedData.date} {selectedData.time}
+                </div>
+              </div>
+
+              <div className='flex items-center justify-between'>
+                <span className='font-semibold'>인원 수</span>
+                <div className='flex items-center space-x-3'>
+                  <button
+                    className='flex h-10 w-10 items-center justify-center rounded-full border border-gray-300 hover:bg-gray-100'
+                    onClick={() =>
+                      setSelectedData((prev) => ({
+                        ...prev,
+                        people: Math.max(1, prev.people - 1),
+                      }))
+                    }
+                  >
+                    -
+                  </button>
+                  <span className='w-12 text-center text-lg font-bold'>{selectedData.people}</span>
+                  <button
+                    className='flex h-10 w-10 items-center justify-center rounded-full border border-gray-300 hover:bg-gray-100'
+                    onClick={() =>
+                      setSelectedData((prev) => ({
+                        ...prev,
+                        people: prev.people + 1,
+                      }))
+                    }
+                  >
+                    +
+                  </button>
+                </div>
+              </div>
+            </div>
+
+            <button className='w-full rounded bg-blue-500 px-4 py-3 text-white' onClick={handlePeopleConfirm}>
+              예약하기 ({selectedData.people}명)
+            </button>
+          </BottomSheet.Content>
+        )}
+      </BottomSheet.Root>
+
+      {/* 애니메이션 다단계 바텀시트 */}
+      <BottomSheet.Root isOpen={animatedMultiStepOpen} onClose={handleAnimatedMultiStepClose}>
+        {animatedCurrentStep === 'datetime' && (
+          <BottomSheet.Content>
+            <h2 className='mb-4 text-lg font-bold'>✨ 날짜 및 시간 선택 (애니메이션)</h2>
+            <div className='mb-4 rounded border-l-4 border-pink-400 bg-pink-50 p-3'>
+              <p className='text-sm text-pink-700'>🎬 확인 버튼을 누르면 바텀시트가 내려갔다가 올라옵니다!</p>
+            </div>
+            <div className='mb-6 space-y-4'>
+              <div className='rounded bg-blue-50 p-3'>
+                <div className='text-sm text-gray-600'>선택된 날짜</div>
+                <div className='font-semibold'>{animatedSelectedData.date}</div>
+              </div>
+              <div className='rounded bg-blue-50 p-3'>
+                <div className='text-sm text-gray-600'>선택된 시간</div>
+                <div className='font-semibold'>{animatedSelectedData.time}</div>
+              </div>
+            </div>
+            <button
+              className={`w-full rounded px-4 py-3 transition-colors ${
+                isTransitioning ? 'cursor-not-allowed bg-gray-400' : 'bg-pink-500 hover:bg-pink-600'
+              } text-white`}
+              disabled={isTransitioning}
+              onClick={handleAnimatedDateTimeConfirm}
+            >
+              {isTransitioning ? '전환 중...' : '확인 (애니메이션 전환)'}
+            </button>
+          </BottomSheet.Content>
+        )}
+
+        {animatedCurrentStep === 'people' && (
+          <BottomSheet.Content>
+            <div className='mb-4 flex items-center'>
+              <button
+                className={`mr-3 rounded p-2 transition-colors ${
+                  isTransitioning ? 'cursor-not-allowed text-gray-400' : 'text-gray-600 hover:bg-gray-100'
+                }`}
+                disabled={isTransitioning}
+                onClick={handleAnimatedBackToDateTime}
+              >
+                ← 뒤로
+              </button>
+              <h2 className='text-lg font-bold'>✨ 인원 선택 (애니메이션)</h2>
+            </div>
+
+            <div className='mb-4 rounded border-l-4 border-pink-400 bg-pink-50 p-3'>
+              <p className='text-sm text-pink-700'>🎬 뒤로가기도 애니메이션으로 전환됩니다!</p>
+            </div>
+
+            <div className='mb-6 space-y-4'>
+              <div className='rounded bg-gray-50 p-3'>
+                <div className='text-sm text-gray-600'>예약 정보</div>
+                <div className='font-semibold'>
+                  {animatedSelectedData.date} {animatedSelectedData.time}
+                </div>
+              </div>
+
+              <div className='flex items-center justify-between'>
+                <span className='font-semibold'>인원 수</span>
+                <div className='flex items-center space-x-3'>
+                  <button
+                    className='flex h-10 w-10 items-center justify-center rounded-full border border-gray-300 hover:bg-gray-100'
+                    onClick={() =>
+                      setAnimatedSelectedData((prev) => ({
+                        ...prev,
+                        people: Math.max(1, prev.people - 1),
+                      }))
+                    }
+                  >
+                    -
+                  </button>
+                  <span className='w-12 text-center text-lg font-bold'>{animatedSelectedData.people}</span>
+                  <button
+                    className='flex h-10 w-10 items-center justify-center rounded-full border border-gray-300 hover:bg-gray-100'
+                    onClick={() =>
+                      setAnimatedSelectedData((prev) => ({
+                        ...prev,
+                        people: prev.people + 1,
+                      }))
+                    }
+                  >
+                    +
+                  </button>
+                </div>
+              </div>
+            </div>
+
+            <button
+              className='w-full rounded bg-pink-500 px-4 py-3 text-white hover:bg-pink-600'
+              onClick={handleAnimatedPeopleConfirm}
+            >
+              예약하기 ({animatedSelectedData.people}명)
+            </button>
+          </BottomSheet.Content>
+        )}
+      </BottomSheet.Root>
+
       <DocTemplate
         description={`
-# BottomSheet 컴포넌트
+# BottomSheet 컴포넌트 - 완전한 구조 + 다단계 예시
 
-Root, Header, Content로 역할이 분리된 바텀시트 컴포넌트입니다.
-
-
+Root, Header, Content로 역할이 명확히 분리된 완전한 바텀시트 컴포넌트입니다.
 
 ## 컴포넌트 구조
 - **BottomSheet.Root**: 기본 구조와 드래그 처리
 - **BottomSheet.Header**: 드래그 핸들 (언제나 닫기 가능)  
 - **BottomSheet.Content**: 동적 높이 + 스크롤 처리
 
+## 다단계 바텀시트 구현 방법
+
+### 권장 방법: 사용자 상태 관리 ⭐
+바텀시트 컴포넌트는 기본 기능에 충실하고, 다단계 로직은 사용자가 처리
+
+\`\`\`tsx
+function MultiStepBottomSheet() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [currentStep, setCurrentStep] = useState('step1'); // 'step1' | 'step2'
+  
+  return (
+    <BottomSheet.Root isOpen={isOpen} onClose={() => setIsOpen(false)}>
+      {currentStep === 'step1' && (
+        <BottomSheet.Content>
+          <h2>1단계: 날짜/시간 선택</h2>
+          <button onClick={() => setCurrentStep('step2')}>
+            다음 단계
+          </button>
+        </BottomSheet.Content>
+      )}
+      
+      {currentStep === 'step2' && (
+        <BottomSheet.Content>
+          <button onClick={() => setCurrentStep('step1')}>← 뒤로</button>
+          <h2>2단계: 인원 선택</h2>
+          <button onClick={() => setIsOpen(false)}>완료</button>
+        </BottomSheet.Content>
+      )}
+    </BottomSheet.Root>
+  );
+}
+\`\`\`
+
+### 장점
+- 🎯 **유연성**: 다양한 시나리오에 대응 가능
+- 🎯 **단순성**: 바텀시트 컴포넌트는 기본 기능에 충실
+- 🎯 **커스터마이징**: 각 단계별로 자유로운 디자인 가능
+- 🎯 **재사용성**: 다른 프로젝트에서도 쉽게 적용
+
 ## 사용 방법
-### 권장 방법 (Content 사용)
+### 기본 방법 (단일 콘텐츠)
 \`\`\`tsx
 <BottomSheet.Root isOpen={isOpen} onClose={onClose}>
   <BottomSheet.Content>
@@ -144,13 +708,11 @@ Root, Header, Content로 역할이 분리된 바텀시트 컴포넌트입니다.
 </BottomSheet.Root>
 \`\`\`
 
-### 커스텀 방법 (직접 스타일링)
+### 다단계 방법 (상태 관리)
 \`\`\`tsx
 <BottomSheet.Root isOpen={isOpen} onClose={onClose}>
-  <div className="p-4 h-64 overflow-y-auto">
-    <h2>제목</h2>
-    <p>직접 높이와 스크롤을 제어할 수 있습니다.</p>
-  </div>
+  {step === 'datetime' && <DateTimeStep />}
+  {step === 'people' && <PeopleStep />}
 </BottomSheet.Root>
 \`\`\`
 
@@ -158,6 +720,7 @@ Root, Header, Content로 역할이 분리된 바텀시트 컴포넌트입니다.
 - 🎯 **Root**: Portal, Overlay, 드래그 처리, Context 제공
 - 🎯 **Header**: iOS 스타일 핸들, 헤더 전용 드래그
 - 🎯 **Content**: 동적 높이, 스크롤 처리, 기본 패딩
+- 🎯 **사용자**: 다단계 로직, 상태 관리, 단계별 UI
 
 ## 헤더 + 스마트 드래그 기능
 - 🎯 **헤더 드래그**: 스크롤 위치와 관계없이 언제나 바텀시트 닫기 가능
@@ -174,6 +737,7 @@ Root, Header, Content로 역할이 분리된 바텀시트 컴포넌트입니다.
 - 📱 **일반적인 사용**: 헤더를 잡고 아래로 드래그해서 닫기
 - 📱 **긴 콘텐츠**: 스크롤을 내린 후에도 헤더로 언제든 닫기 가능
 - 📱 **스크롤 중**: 콘텐츠 드래그는 스크롤, 헤더 드래그는 닫기
+- 📱 **다단계**: 상태 관리로 단계별 UI 전환
 
 ## 예정 기능
 - ⏳ 스크롤 최적화
@@ -195,54 +759,6 @@ Root, Header, Content로 역할이 분리된 바텀시트 컴포넌트입니다.
       />
 
       {/* 실제 컴포넌트를 아래에 작성해주세요 */}
-      <div className='mb-4 space-x-2'>
-        <button
-          className='rounded bg-green-500 px-4 py-2 text-white hover:bg-green-600'
-          onClick={() => handleOpenBottomSheet('short')}
-        >
-          짧은 콘텐츠
-        </button>
-        <button
-          className='rounded bg-blue-500 px-4 py-2 text-white hover:bg-blue-600'
-          onClick={() => handleOpenBottomSheet('medium')}
-        >
-          중간 콘텐츠
-        </button>
-        <button
-          className='rounded bg-purple-500 px-4 py-2 text-white hover:bg-purple-600'
-          onClick={() => handleOpenBottomSheet('long')}
-        >
-          긴 콘텐츠 (🎯 헤더 + 스마트 드래그)
-        </button>
-      </div>
-
-      {/* 스크롤 테스트를 위한 긴 콘텐츠 */}
-      <div className='mb-8'>
-        <h3 className='mb-4 text-lg font-bold'>헤더 + 스마트 드래그 테스트 설명</h3>
-        <div className='space-y-4'>
-          <div className='rounded bg-green-50 p-4'>
-            <h4 className='font-semibold text-green-800'>🟢 짧은/중간 콘텐츠</h4>
-            <p className='text-green-700'>스크롤이 없어서 어디서든 드래그로 닫기 가능</p>
-          </div>
-          <div className='rounded bg-red-50 p-4'>
-            <h4 className='font-semibold text-red-800'>🎯 헤더 드래그 (모든 콘텐츠)</h4>
-            <p className='text-red-700'>
-              <strong>헤더 영역을 드래그하면 스크롤 위치와 관계없이 언제나 바텀시트 닫기</strong>
-            </p>
-          </div>
-          <div className='rounded bg-orange-50 p-4'>
-            <h4 className='font-semibold text-orange-800'>🧠 긴 콘텐츠 (콘텐츠 스마트 드래그)</h4>
-            <div className='space-y-2 text-orange-700'>
-              <p>
-                <strong>✅ 콘텐츠 드래그 (스크롤 맨 위)</strong>: 아래로 드래그 → 바텀시트 닫기
-              </p>
-              <p>
-                <strong>🚫 콘텐츠 드래그 (스크롤 중간/아래)</strong>: 아래로 드래그 → 스크롤만 동작 (바텀시트 안 닫힘)
-              </p>
-            </div>
-          </div>
-        </div>
-      </div>
       {/* 예시 코드 */}
       <DocCode
         code={`<BottomSheet.Root isOpen={isOpen} onClose={onClose}>
@@ -253,20 +769,33 @@ Root, Header, Content로 역할이 분리된 바텀시트 컴포넌트입니다.
 </BottomSheet.Root>`}
       />
 
-      {/* Playground는 편집 가능한 코드 블록입니다. */}
-      <div className='mt-24'>
-        <Playground code={code} scope={{ BottomSheet, useState, isOpen, onClose: () => setIsOpen(false) }} />
-      </div>
+      {/* 다단계 바텀시트 예시 코드 */}
+      <h3 className='mt-8 mb-4 text-lg font-bold'>다단계 바텀시트 구현 예시</h3>
+      <DocCode code={multiStepCode} />
 
-      {/* 스크롤 테스트를 위한 추가 콘텐츠 */}
-      <div className='mt-24 space-y-4'>
-        <h3 className='text-lg font-bold'>추가 스크롤 테스트 영역</h3>
-        {Array.from({ length: 20 }, (_, i) => (
-          <div key={i + 10} className='rounded bg-blue-50 p-4'>
-            <p>추가 테스트 콘텐츠 {i + 1} - 헤더 + 스마트 드래그가 적용된 바텀시트를 테스트해보세요.</p>
-          </div>
-        ))}
+      {/* 애니메이션 다단계 바텀시트 예시 코드 */}
+      <h3 className='mt-8 mb-4 text-lg font-bold'>✨ 애니메이션 다단계 바텀시트 (내려갔다가 올라오는 전환)</h3>
+      <div className='mb-4 rounded border-l-4 border-pink-400 bg-pink-50 p-4'>
+        <h4 className='mb-2 font-semibold text-pink-800'>🎬 애니메이션 전환 원리</h4>
+        <div className='space-y-1 text-sm text-pink-700'>
+          <p>
+            <strong>1단계</strong>: 확인 버튼 클릭 → <code>setIsOpen(false)</code>
+          </p>
+          <p>
+            <strong>2단계</strong>: 바텀시트 닫기 애니메이션 (0.3초)
+          </p>
+          <p>
+            <strong>3단계</strong>: <code>setTimeout(300ms)</code> 대기
+          </p>
+          <p>
+            <strong>4단계</strong>: 다음 스텝으로 변경 + <code>setIsOpen(true)</code>
+          </p>
+          <p>
+            <strong>결과</strong>: 바텀시트가 내려갔다가 새 콘텐츠로 다시 올라옴! ✨
+          </p>
+        </div>
       </div>
+      <DocCode code={animatedMultiStepCode} />
     </>
   );
 }

--- a/packages/design-system/src/pages/BottomSheetDoc.tsx
+++ b/packages/design-system/src/pages/BottomSheetDoc.tsx
@@ -1,35 +1,271 @@
+import { useState } from 'react';
+
 import Playground from '@/layouts/Playground';
 
+import { BottomSheet } from '../components/bottomsheet';
 import DocTemplate, { DocCode } from '../layouts/DocTemplate';
-// import BottomSheet from '../components/BottomSheet';
 
 /* Playground는 편집 가능한 코드 블록입니다. */
 /* Playground에서 사용할 예시 코드를 작성해주세요. */
-const code = `예시 코드를 작성해주세요.`;
+const code = `
+// 테스트는 위에 Example 버튼을 눌러서 해주세요.
+
+<BottomSheet.Root isOpen={isOpen} onClose={onClose}>
+  <BottomSheet.Content>
+    <h2>제목</h2>
+    <p>역할이 명확히 분리된 완전한 바텀시트!</p>
+  </BottomSheet.Content>
+</BottomSheet.Root>`;
 
 export default function BottomSheetDoc() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [contentType, setContentType] = useState<'short' | 'medium' | 'long'>('short');
+
+  const shortContent = (
+    <BottomSheet.Content>
+      <h2 className='mb-4 text-lg font-bold'>짧은 콘텐츠 테스트</h2>
+      <p className='mb-4'>적은 양의 콘텐츠입니다. 바텀시트가 콘텐츠에 맞게 작은 높이로 자동 조절됩니다.</p>
+      <div className='mb-4 rounded bg-green-50 p-3'>
+        <p className='text-sm text-green-700'>✅ 어디서든 드래그로 닫을 수 있습니다</p>
+      </div>
+      <button className='rounded bg-red-500 px-4 py-2 text-white' onClick={() => setIsOpen(false)}>
+        닫기
+      </button>
+    </BottomSheet.Content>
+  );
+
+  const mediumContent = (
+    <BottomSheet.Content>
+      <h2 className='mb-4 text-lg font-bold'>중간 콘텐츠 테스트</h2>
+      <div className='mb-4 rounded bg-blue-50 p-3'>
+        <p className='text-sm text-blue-700'>✅ 어디서든 드래그로 닫을 수 있습니다</p>
+      </div>
+      <div className='mb-4 space-y-3'>
+        {Array.from({ length: 8 }, (_, i) => (
+          <div key={i} className='rounded bg-gray-100 p-3'>
+            <p>중간 길이 콘텐츠 {i + 1} - 적당한 양의 콘텐츠로 중간 높이가 됩니다.</p>
+          </div>
+        ))}
+      </div>
+      <button className='rounded bg-red-500 px-4 py-2 text-white' onClick={() => setIsOpen(false)}>
+        닫기
+      </button>
+    </BottomSheet.Content>
+  );
+
+  const longContent = (
+    <BottomSheet.Content>
+      <h2 className='mb-4 text-lg font-bold'>긴 콘텐츠 테스트 (헤더 + 스마트 드래그)</h2>
+      <div className='mb-4 border-l-4 border-orange-400 bg-orange-50 p-3'>
+        <h4 className='mb-2 font-semibold text-orange-800'>🎯 헤더 + 스마트 드래그 기능</h4>
+        <ul className='space-y-1 text-sm text-orange-700'>
+          <li>
+            • <strong>헤더 드래그</strong>: 스크롤 위치와 관계없이 언제나 바텀시트 닫기 가능
+          </li>
+          <li>
+            • <strong>콘텐츠 드래그 (스크롤 맨 위)</strong>: 바텀시트 닫기 가능
+          </li>
+          <li>
+            • <strong>콘텐츠 드래그 (스크롤 중간/아래)</strong>: 스크롤만 동작 (바텀시트 안 닫힘)
+          </li>
+        </ul>
+      </div>
+      <div className='mb-4 space-y-3'>
+        {Array.from({ length: 25 }, (_, i) => (
+          <div key={i} className='rounded bg-blue-50 p-3'>
+            <h3 className='font-semibold'>항목 {i + 1}</h3>
+            <p>
+              긴 콘텐츠 예시입니다. 스크롤을 내린 상태에서 콘텐츠를 드래그하면 바텀시트가 닫히지 않지만, 헤더를
+              드래그하면 언제나 닫힙니다.
+            </p>
+            {i === 0 && (
+              <div className='mt-2 space-y-1 text-sm'>
+                <p className='text-red-600'>
+                  🎯 <strong>헤더 드래그</strong>: 언제나 바텀시트 닫기 가능
+                </p>
+                <p className='text-green-600'>
+                  ✅ <strong>콘텐츠 드래그</strong>: 현재 맨 위라서 바텀시트 닫기 가능
+                </p>
+              </div>
+            )}
+            {i === 10 && (
+              <div className='mt-2 space-y-1 text-sm'>
+                <p className='text-red-600'>
+                  🎯 <strong>헤더 드래그</strong>: 언제나 바텀시트 닫기 가능
+                </p>
+                <p className='text-blue-600'>
+                  🚫 <strong>콘텐츠 드래그</strong>: 스크롤을 내렸다면 바텀시트 안 닫힘
+                </p>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+      <button className='sticky bottom-0 rounded bg-red-500 px-4 py-2 text-white' onClick={() => setIsOpen(false)}>
+        닫기
+      </button>
+    </BottomSheet.Content>
+  );
+
+  const handleOpenBottomSheet = (type: 'short' | 'medium' | 'long') => {
+    setContentType(type);
+    setIsOpen(true);
+  };
+
   return (
     <>
+      <BottomSheet.Root isOpen={isOpen} onClose={() => setIsOpen(false)}>
+        {contentType === 'short' && shortContent}
+        {contentType === 'medium' && mediumContent}
+        {contentType === 'long' && longContent}
+      </BottomSheet.Root>
+
       <DocTemplate
         description={`
 # BottomSheet 컴포넌트
 
-간단한 설명을 작성해주세요.
+Root, Header, Content로 역할이 분리된 바텀시트 컴포넌트입니다.
+
+
+
+## 컴포넌트 구조
+- **BottomSheet.Root**: 기본 구조와 드래그 처리
+- **BottomSheet.Header**: 드래그 핸들 (언제나 닫기 가능)  
+- **BottomSheet.Content**: 동적 높이 + 스크롤 처리
+
+## 사용 방법
+### 권장 방법 (Content 사용)
+\`\`\`tsx
+<BottomSheet.Root isOpen={isOpen} onClose={onClose}>
+  <BottomSheet.Content>
+    <h2>제목</h2>
+    <p>동적 높이와 스크롤이 자동 처리됩니다!</p>
+  </BottomSheet.Content>
+</BottomSheet.Root>
+\`\`\`
+
+### 커스텀 방법 (직접 스타일링)
+\`\`\`tsx
+<BottomSheet.Root isOpen={isOpen} onClose={onClose}>
+  <div className="p-4 h-64 overflow-y-auto">
+    <h2>제목</h2>
+    <p>직접 높이와 스크롤을 제어할 수 있습니다.</p>
+  </div>
+</BottomSheet.Root>
+\`\`\`
+
+## 역할 분리
+- 🎯 **Root**: Portal, Overlay, 드래그 처리, Context 제공
+- 🎯 **Header**: iOS 스타일 핸들, 헤더 전용 드래그
+- 🎯 **Content**: 동적 높이, 스크롤 처리, 기본 패딩
+
+## 헤더 + 스마트 드래그 기능
+- 🎯 **헤더 드래그**: 스크롤 위치와 관계없이 언제나 바텀시트 닫기 가능
+- 🧠 **콘텐츠 스마트 드래그**: 스크롤 위치에 따라 조건부 바텀시트 닫기
+- 🎯 **영역별 구분**: 터치 시작 위치를 자동 감지하여 다른 동작 적용
+- 🧠 **UX 최적화**: 사용자 의도에 맞는 자연스러운 상호작용
+
+## 드래그 동작 로직
+1. **헤더 영역 드래그**: 언제나 바텀시트 닫기 (스크롤 위치 무관)
+2. **콘텐츠 영역 드래그 (스크롤 맨 위)**: 바텀시트 닫기
+3. **콘텐츠 영역 드래그 (스크롤 중간/아래)**: 스크롤만 동작 (바텀시트 안 닫힘)
+
+## 실제 사용 시나리오
+- 📱 **일반적인 사용**: 헤더를 잡고 아래로 드래그해서 닫기
+- 📱 **긴 콘텐츠**: 스크롤을 내린 후에도 헤더로 언제든 닫기 가능
+- 📱 **스크롤 중**: 콘텐츠 드래그는 스크롤, 헤더 드래그는 닫기
+
+## 예정 기능
+- ⏳ 스크롤 최적화
+- ⏳ 접근성 기능 (포커스 트랩)
+- ⏳ 커스텀 드래그 임계값 설정
 `}
         propsDescription={`
-| 이름 | 타입 | 설명 |
-|------|------|------|
-| example | string | 예시 prop입니다. |
+| 컴포넌트 | 프로퍼티 | 타입 | 설명 |
+|----------|----------|------|------|
+| Root | isOpen | boolean | 바텀시트 열림 상태 |
+| Root | onClose | () => void | 바텀시트 닫기 함수 |
+| Root | children | ReactNode | 바텀시트 내부 콘텐츠 |
+| Root | className | string? | 추가 CSS 클래스 |
+| Header | className | string? | 추가 CSS 클래스 |
+| Content | children | ReactNode | 콘텐츠 내용 |
+| Content | className | string? | 추가 CSS 클래스 |
 `}
         title='BottomSheet'
       />
+
       {/* 실제 컴포넌트를 아래에 작성해주세요 */}
+      <div className='mb-4 space-x-2'>
+        <button
+          className='rounded bg-green-500 px-4 py-2 text-white hover:bg-green-600'
+          onClick={() => handleOpenBottomSheet('short')}
+        >
+          짧은 콘텐츠
+        </button>
+        <button
+          className='rounded bg-blue-500 px-4 py-2 text-white hover:bg-blue-600'
+          onClick={() => handleOpenBottomSheet('medium')}
+        >
+          중간 콘텐츠
+        </button>
+        <button
+          className='rounded bg-purple-500 px-4 py-2 text-white hover:bg-purple-600'
+          onClick={() => handleOpenBottomSheet('long')}
+        >
+          긴 콘텐츠 (🎯 헤더 + 스마트 드래그)
+        </button>
+      </div>
+
+      {/* 스크롤 테스트를 위한 긴 콘텐츠 */}
+      <div className='mb-8'>
+        <h3 className='mb-4 text-lg font-bold'>헤더 + 스마트 드래그 테스트 설명</h3>
+        <div className='space-y-4'>
+          <div className='rounded bg-green-50 p-4'>
+            <h4 className='font-semibold text-green-800'>🟢 짧은/중간 콘텐츠</h4>
+            <p className='text-green-700'>스크롤이 없어서 어디서든 드래그로 닫기 가능</p>
+          </div>
+          <div className='rounded bg-red-50 p-4'>
+            <h4 className='font-semibold text-red-800'>🎯 헤더 드래그 (모든 콘텐츠)</h4>
+            <p className='text-red-700'>
+              <strong>헤더 영역을 드래그하면 스크롤 위치와 관계없이 언제나 바텀시트 닫기</strong>
+            </p>
+          </div>
+          <div className='rounded bg-orange-50 p-4'>
+            <h4 className='font-semibold text-orange-800'>🧠 긴 콘텐츠 (콘텐츠 스마트 드래그)</h4>
+            <div className='space-y-2 text-orange-700'>
+              <p>
+                <strong>✅ 콘텐츠 드래그 (스크롤 맨 위)</strong>: 아래로 드래그 → 바텀시트 닫기
+              </p>
+              <p>
+                <strong>🚫 콘텐츠 드래그 (스크롤 중간/아래)</strong>: 아래로 드래그 → 스크롤만 동작 (바텀시트 안 닫힘)
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
       {/* 예시 코드 */}
-      <DocCode code={`<BottomSheet variant="primary">Click me</BottomSheet>`} />
+      <DocCode
+        code={`<BottomSheet.Root isOpen={isOpen} onClose={onClose}>
+  <BottomSheet.Content>
+    <h2>제목</h2>
+    <p>역할이 명확히 분리된 완전한 바텀시트!</p>
+  </BottomSheet.Content>
+</BottomSheet.Root>`}
+      />
 
       {/* Playground는 편집 가능한 코드 블록입니다. */}
       <div className='mt-24'>
-        <Playground code={code} scope={{}} />
+        <Playground code={code} scope={{ BottomSheet, useState, isOpen, onClose: () => setIsOpen(false) }} />
+      </div>
+
+      {/* 스크롤 테스트를 위한 추가 콘텐츠 */}
+      <div className='mt-24 space-y-4'>
+        <h3 className='text-lg font-bold'>추가 스크롤 테스트 영역</h3>
+        {Array.from({ length: 20 }, (_, i) => (
+          <div key={i + 10} className='rounded bg-blue-50 p-4'>
+            <p>추가 테스트 콘텐츠 {i + 1} - 헤더 + 스마트 드래그가 적용된 바텀시트를 테스트해보세요.</p>
+          </div>
+        ))}
       </div>
     </>
   );

--- a/packages/design-system/src/pages/BottomSheetDoc.tsx
+++ b/packages/design-system/src/pages/BottomSheetDoc.tsx
@@ -1,0 +1,36 @@
+import Playground from '@/layouts/Playground';
+
+import DocTemplate, { DocCode } from '../layouts/DocTemplate';
+// import BottomSheet from '../components/BottomSheet';
+
+/* Playground는 편집 가능한 코드 블록입니다. */
+/* Playground에서 사용할 예시 코드를 작성해주세요. */
+const code = `예시 코드를 작성해주세요.`;
+
+export default function BottomSheetDoc() {
+  return (
+    <>
+      <DocTemplate
+        description={`
+# BottomSheet 컴포넌트
+
+간단한 설명을 작성해주세요.
+`}
+        propsDescription={`
+| 이름 | 타입 | 설명 |
+|------|------|------|
+| example | string | 예시 prop입니다. |
+`}
+        title='BottomSheet'
+      />
+      {/* 실제 컴포넌트를 아래에 작성해주세요 */}
+      {/* 예시 코드 */}
+      <DocCode code={`<BottomSheet variant="primary">Click me</BottomSheet>`} />
+
+      {/* Playground는 편집 가능한 코드 블록입니다. */}
+      <div className='mt-24'>
+        <Playground code={code} scope={{}} />
+      </div>
+    </>
+  );
+}

--- a/packages/design-system/src/routes/index.tsx
+++ b/packages/design-system/src/routes/index.tsx
@@ -1,4 +1,5 @@
 import Sidebar from '@layouts/Sidebar';
+import BottomSheetDoc from '@pages/BottomSheetDoc';
 import ButtonDoc from '@pages/ButtonDoc';
 import CalendarDoc from '@pages/CalendarDoc';
 import DropdownDoc from '@pages/DropdownDoc';
@@ -110,6 +111,10 @@ const router = createBrowserRouter([
       {
         path: 'Calendar',
         element: <CalendarDoc />,
+      },
+      {
+        path: 'BottomSheet',
+        element: <BottomSheetDoc />,
       },
     ],
   },


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- #76 

## 📌 작업 내용
<!-- 해당 PR의 변경 사항을 자세하게 적어주세요.-->

- 바텀 시트 구현

## ✅ 체크리스트

- [x] PR 하기 전에 이슈에서 빼먹은건 없는지 확인했습니다
  - [x] 라벨 및 마일스톤을 사이드 탭에서 등록했습니다.
- [x] PR을 보내는 브랜치가 올바른지 확인했습니다.
- [x] 팀원들이 리뷰하기 쉽도록 설명을 자세하게 작성했습니다.
- [x] 변경사항을 충분히 테스트 했습니다.
- [x] (함수를 구현 했을 때) JSDoc을 양식에 맞춰서 작성했습니다.
- [x] 컨벤션에 맞게 구현했습니다.

## 📷 UI 변경 사항 (선택)
<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->
<img width="1488" height="720" alt="image" src="https://github.com/user-attachments/assets/f40b3fe7-0808-4a19-bce2-d7959b5a2b6f" />

<img width="578" height="1222" alt="image" src="https://github.com/user-attachments/assets/eda07004-ae05-4c23-bf48-1e7666cf1fdc" />

https://github.com/user-attachments/assets/56e4bd81-9d41-431c-94ba-464680753098

> 닫기 버튼은 무시해주세요 sticky로 임시로 붙혀둔 버튼이라 사용하실때 없습니다!
## ❓무슨 문제가 발생했나요? (선택)

-

## 💬 기타 참고 사항 (선택)
<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->

- 아마 지현님이랑 저만 사용할 것 같아서 다행입니다(?)
@kjhyun0830 디자인 페이지 예시 보시면 좀 복잡하다고 생각하실수도있는데 이건 상세페이지에서 step으로 넘어갈때 코드라 지현님은 
```tsx
<BottomSheet.Root isOpen={isOpen} onClose={onClose}>
  <BottomSheet.Content>
    // 요기에 예약 현황에서 사용하시는 컴포넌트 넣으시면 됩니다
  </BottomSheet.Content>
</BottomSheet.Root>
```

드래그 관련해서.. 이슈가 많아서 3번 갈아엎은 친구입니다 ~~폐기처분 마렵긴하지만~~ content가 바텀시트의 크기보다 크더라도 내부 스크롤 가능하도록 했고 아래로 내려왔어도 header(ㅡ 모양 핸들)을 잡고 내리면 꺼지도록 구현했습니다.
content가 바텀시트의 최대 높이까지 도달하지않는 경우 바텀시트 아무데나 잡고 30프로 이상 아래로 내리면 바텀시트는 꺼집니다!
