### PR TITLE
알림 Popover UI 구현

### DIFF
--- a/apps/what-today/src/components/Header.tsx
+++ b/apps/what-today/src/components/Header.tsx
@@ -1,13 +1,14 @@
-import { BellIcon, Button, DotIcon, NotificationCard, Popover, ProfileLogo } from '@what-today/design-system';
+import { ProfileLogo } from '@what-today/design-system';
 import { ImageLogo } from '@what-today/design-system';
 import { TextLogo } from '@what-today/design-system';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
 import { useResponsive } from '@/hooks/useResponsive';
 import { useWhatTodayStore } from '@/stores';
 
+import NotificationPopover from './notification/NotificationPopover';
+
 export default function Header() {
-  const navigate = useNavigate();
   const { user, isLoggedIn } = useWhatTodayStore();
   const screenSize = useResponsive();
   const isMobile = screenSize === 'sm';
@@ -21,62 +22,7 @@ export default function Header() {
 
       {isLoggedIn ? (
         <div className='text-md flex items-center gap-8 text-gray-950'>
-          <Popover.Root direction={isMobile ? 'bottom-center' : 'bottom-right'}>
-            <Popover.Trigger className='flex items-center'>
-              <Button
-                aria-describedby='notification-dot'
-                aria-label='알림'
-                className='relative flex h-fit w-fit p-0'
-                variant='none'
-              >
-                {/* 알람 있을 때 사용 */}
-                <DotIcon
-                  aria-label='새 알림 있음'
-                  className='absolute top-2 left-12 size-8'
-                  color='var(--color-red-500)'
-                  id='notification-dot'
-                />
-                <BellIcon className='size-20' color='var(--color-gray-600)' />
-              </Button>
-            </Popover.Trigger>
-            <Popover.Content className='mt-8 rounded-2xl border border-gray-100 bg-white p-10 shadow-sm'>
-              <h1 className='my-8 ml-auto px-16 font-bold'>알림 6개</h1>
-
-              <div className='max-h-400 w-300 divide-y divide-gray-50 overflow-y-scroll'>
-                {/* 더미데이터 */}
-                <NotificationCard
-                  content='바람과 함께하는 한강 요가(2025-07-20 07:00~08:00) 예약이 승인되었습니다.'
-                  onClickDetail={() => navigate('/mypage/reservations-list')}
-                  onDelete={() => alert('삭제 API 요청')}
-                />
-                <NotificationCard
-                  content='전통 다도 체험 클래스(2025-09-12 14:00~15:30) 예약이 승인되었습니다.'
-                  onClickDetail={() => navigate('/mypage/reservations-list')}
-                  onDelete={() => alert('삭제 API 요청')}
-                />
-                <NotificationCard
-                  content='한강 야외 영화 상영회(2025-07-27 20:00~22:00) 예약이 거절되었습니다.'
-                  onClickDetail={() => navigate('/mypage/reservations-list')}
-                  onDelete={() => alert('삭제 API 요청')}
-                />
-                <NotificationCard
-                  content='전통 다도 체험 클래스(2025-09-12 14:00~15:30) 예약이 승인되었습니다.'
-                  onClickDetail={() => navigate('/mypage/reservations-list')}
-                  onDelete={() => alert('삭제 API 요청')}
-                />
-                <NotificationCard
-                  content='한강 야외 영화 상영회(2025-07-27 20:00~22:00) 예약이 거절되었습니다.'
-                  onClickDetail={() => navigate('/mypage/reservations-list')}
-                  onDelete={() => alert('삭제 API 요청')}
-                />
-                <NotificationCard
-                  content='메시지 파싱에 실패하면 이렇게 보여집니다.'
-                  onClickDetail={() => navigate('/mypage/reservations-list')}
-                  onDelete={() => alert('삭제 API 요청')}
-                />
-              </div>
-            </Popover.Content>
-          </Popover.Root>
+          <NotificationPopover isMobile={isMobile} />
 
           <div className='mx-12 h-16 w-px bg-gray-100' />
 

--- a/apps/what-today/src/components/Header.tsx
+++ b/apps/what-today/src/components/Header.tsx
@@ -1,12 +1,16 @@
-import { BellIcon, DotIcon, ProfileLogo } from '@what-today/design-system';
+import { BellIcon, Button, DotIcon, NotificationCard, Popover, ProfileLogo } from '@what-today/design-system';
 import { ImageLogo } from '@what-today/design-system';
 import { TextLogo } from '@what-today/design-system';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 
+import { useResponsive } from '@/hooks/useResponsive';
 import { useWhatTodayStore } from '@/stores';
 
 export default function Header() {
+  const navigate = useNavigate();
   const { user, isLoggedIn } = useWhatTodayStore();
+  const screenSize = useResponsive();
+  const isMobile = screenSize === 'sm';
 
   return (
     <header className='relative z-50 flex w-full justify-between py-16'>
@@ -17,21 +21,62 @@ export default function Header() {
 
       {isLoggedIn ? (
         <div className='text-md flex items-center gap-8 text-gray-950'>
-          <button
-            aria-describedby='notification-dot'
-            aria-label='알림'
-            className='relative cursor-pointer hover:opacity-60'
-            type='button'
-          >
-            {/* 알람 있을 때 사용 */}
-            <DotIcon
-              aria-label='새 알림 있음'
-              className='absolute top-2 left-12 size-8'
-              color='var(--color-red-500)'
-              id='notification-dot'
-            />
-            <BellIcon className='size-20' color='var(--color-gray-600)' />
-          </button>
+          <Popover.Root direction={isMobile ? 'bottom-center' : 'bottom-right'}>
+            <Popover.Trigger className='flex items-center'>
+              <Button
+                aria-describedby='notification-dot'
+                aria-label='알림'
+                className='relative flex h-fit w-fit p-0'
+                variant='none'
+              >
+                {/* 알람 있을 때 사용 */}
+                <DotIcon
+                  aria-label='새 알림 있음'
+                  className='absolute top-2 left-12 size-8'
+                  color='var(--color-red-500)'
+                  id='notification-dot'
+                />
+                <BellIcon className='size-20' color='var(--color-gray-600)' />
+              </Button>
+            </Popover.Trigger>
+            <Popover.Content className='mt-8 rounded-2xl border border-gray-100 bg-white p-10 shadow-sm'>
+              <h1 className='my-8 ml-auto px-16 font-bold'>알림 6개</h1>
+
+              <div className='max-h-400 w-300 divide-y divide-gray-50 overflow-y-scroll'>
+                {/* 더미데이터 */}
+                <NotificationCard
+                  content='바람과 함께하는 한강 요가(2025-07-20 07:00~08:00) 예약이 승인되었습니다.'
+                  onClickDetail={() => navigate('/mypage/reservations-list')}
+                  onDelete={() => alert('삭제 API 요청')}
+                />
+                <NotificationCard
+                  content='전통 다도 체험 클래스(2025-09-12 14:00~15:30) 예약이 승인되었습니다.'
+                  onClickDetail={() => navigate('/mypage/reservations-list')}
+                  onDelete={() => alert('삭제 API 요청')}
+                />
+                <NotificationCard
+                  content='한강 야외 영화 상영회(2025-07-27 20:00~22:00) 예약이 거절되었습니다.'
+                  onClickDetail={() => navigate('/mypage/reservations-list')}
+                  onDelete={() => alert('삭제 API 요청')}
+                />
+                <NotificationCard
+                  content='전통 다도 체험 클래스(2025-09-12 14:00~15:30) 예약이 승인되었습니다.'
+                  onClickDetail={() => navigate('/mypage/reservations-list')}
+                  onDelete={() => alert('삭제 API 요청')}
+                />
+                <NotificationCard
+                  content='한강 야외 영화 상영회(2025-07-27 20:00~22:00) 예약이 거절되었습니다.'
+                  onClickDetail={() => navigate('/mypage/reservations-list')}
+                  onDelete={() => alert('삭제 API 요청')}
+                />
+                <NotificationCard
+                  content='메시지 파싱에 실패하면 이렇게 보여집니다.'
+                  onClickDetail={() => navigate('/mypage/reservations-list')}
+                  onDelete={() => alert('삭제 API 요청')}
+                />
+              </div>
+            </Popover.Content>
+          </Popover.Root>
 
           <div className='mx-12 h-16 w-px bg-gray-100' />
 

--- a/apps/what-today/src/components/notification/NotificationPopover.tsx
+++ b/apps/what-today/src/components/notification/NotificationPopover.tsx
@@ -1,4 +1,5 @@
 import { BellIcon, Button, DotIcon, NotificationCard, Popover } from '@what-today/design-system';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 interface NotificationPopoverProps {
@@ -7,15 +8,17 @@ interface NotificationPopoverProps {
 
 export default function NotificationPopover({ isMobile }: NotificationPopoverProps) {
   const navigate = useNavigate();
+  const [open, setOpen] = useState(false);
 
   return (
-    <Popover.Root direction={isMobile ? 'bottom-center' : 'bottom-right'}>
+    <Popover.Root direction={isMobile ? 'bottom-center' : 'bottom-right'} open={open} onOpenChange={setOpen}>
       <Popover.Trigger className='flex items-center'>
         <Button
           aria-describedby='notification-dot'
           aria-label='알림'
           className='relative flex h-fit w-fit p-0'
           variant='none'
+          onClick={() => setOpen((prev) => !prev)}
         >
           <DotIcon
             aria-label='새 알림 있음'
@@ -23,7 +26,7 @@ export default function NotificationPopover({ isMobile }: NotificationPopoverPro
             color='var(--color-red-500)'
             id='notification-dot'
           />
-          <BellIcon className='size-20' color='var(--color-gray-600)' />
+          <BellIcon className='size-20' color={open ? 'var(--color-primary-500)' : 'var(--color-gray-600)'} />
         </Button>
       </Popover.Trigger>
       <Popover.Content className='mt-8 rounded-2xl border border-gray-100 bg-white p-10 shadow-sm'>
@@ -33,32 +36,42 @@ export default function NotificationPopover({ isMobile }: NotificationPopoverPro
           {/* 더미데이터 */}
           <NotificationCard
             content='바람과 함께하는 한강 요가(2025-07-20 07:00~08:00) 예약이 승인되었습니다.'
-            onClickDetail={() => navigate('/mypage/reservations-list')}
+            onClickDetail={() => {
+              navigate('/mypage/reservations-list');
+              setOpen((prev) => !prev);
+            }}
             onDelete={() => alert('삭제 API 요청')}
           />
           <NotificationCard
             content='전통 다도 체험 클래스(2025-09-12 14:00~15:30) 예약이 승인되었습니다.'
-            onClickDetail={() => navigate('/mypage/reservations-list')}
+            onClickDetail={() => {
+              navigate('/mypage/reservations-list');
+              setOpen((prev) => !prev);
+            }}
             onDelete={() => alert('삭제 API 요청')}
           />
           <NotificationCard
             content='한강 야외 영화 상영회(2025-07-27 20:00~22:00) 예약이 거절되었습니다.'
-            onClickDetail={() => navigate('/mypage/reservations-list')}
+            onClickDetail={() => {
+              navigate('/mypage/reservations-list');
+              setOpen((prev) => !prev);
+            }}
             onDelete={() => alert('삭제 API 요청')}
           />
           <NotificationCard
             content='전통 다도 체험 클래스(2025-09-12 14:00~15:30) 예약이 승인되었습니다.'
-            onClickDetail={() => navigate('/mypage/reservations-list')}
+            onClickDetail={() => {
+              navigate('/mypage/reservations-list');
+              setOpen((prev) => !prev);
+            }}
             onDelete={() => alert('삭제 API 요청')}
           />
           <NotificationCard
             content='한강 야외 영화 상영회(2025-07-27 20:00~22:00) 예약이 거절되었습니다.'
-            onClickDetail={() => navigate('/mypage/reservations-list')}
-            onDelete={() => alert('삭제 API 요청')}
-          />
-          <NotificationCard
-            content='메시지 파싱에 실패하면 이렇게 보여집니다.'
-            onClickDetail={() => navigate('/mypage/reservations-list')}
+            onClickDetail={() => {
+              navigate('/mypage/reservations-list');
+              setOpen((prev) => !prev);
+            }}
             onDelete={() => alert('삭제 API 요청')}
           />
         </div>

--- a/apps/what-today/src/components/notification/NotificationPopover.tsx
+++ b/apps/what-today/src/components/notification/NotificationPopover.tsx
@@ -1,0 +1,68 @@
+import { BellIcon, Button, DotIcon, NotificationCard, Popover } from '@what-today/design-system';
+import { useNavigate } from 'react-router-dom';
+
+interface NotificationPopoverProps {
+  isMobile: boolean;
+}
+
+export default function NotificationPopover({ isMobile }: NotificationPopoverProps) {
+  const navigate = useNavigate();
+
+  return (
+    <Popover.Root direction={isMobile ? 'bottom-center' : 'bottom-right'}>
+      <Popover.Trigger className='flex items-center'>
+        <Button
+          aria-describedby='notification-dot'
+          aria-label='알림'
+          className='relative flex h-fit w-fit p-0'
+          variant='none'
+        >
+          <DotIcon
+            aria-label='새 알림 있음'
+            className='absolute top-2 left-12 size-8'
+            color='var(--color-red-500)'
+            id='notification-dot'
+          />
+          <BellIcon className='size-20' color='var(--color-gray-600)' />
+        </Button>
+      </Popover.Trigger>
+      <Popover.Content className='mt-8 rounded-2xl border border-gray-100 bg-white p-10 shadow-sm'>
+        <h1 className='my-8 ml-auto px-16 font-bold'>알림 6개</h1>
+
+        <div className='max-h-400 w-300 divide-y divide-gray-50 overflow-y-scroll'>
+          {/* 더미데이터 */}
+          <NotificationCard
+            content='바람과 함께하는 한강 요가(2025-07-20 07:00~08:00) 예약이 승인되었습니다.'
+            onClickDetail={() => navigate('/mypage/reservations-list')}
+            onDelete={() => alert('삭제 API 요청')}
+          />
+          <NotificationCard
+            content='전통 다도 체험 클래스(2025-09-12 14:00~15:30) 예약이 승인되었습니다.'
+            onClickDetail={() => navigate('/mypage/reservations-list')}
+            onDelete={() => alert('삭제 API 요청')}
+          />
+          <NotificationCard
+            content='한강 야외 영화 상영회(2025-07-27 20:00~22:00) 예약이 거절되었습니다.'
+            onClickDetail={() => navigate('/mypage/reservations-list')}
+            onDelete={() => alert('삭제 API 요청')}
+          />
+          <NotificationCard
+            content='전통 다도 체험 클래스(2025-09-12 14:00~15:30) 예약이 승인되었습니다.'
+            onClickDetail={() => navigate('/mypage/reservations-list')}
+            onDelete={() => alert('삭제 API 요청')}
+          />
+          <NotificationCard
+            content='한강 야외 영화 상영회(2025-07-27 20:00~22:00) 예약이 거절되었습니다.'
+            onClickDetail={() => navigate('/mypage/reservations-list')}
+            onDelete={() => alert('삭제 API 요청')}
+          />
+          <NotificationCard
+            content='메시지 파싱에 실패하면 이렇게 보여집니다.'
+            onClickDetail={() => navigate('/mypage/reservations-list')}
+            onDelete={() => alert('삭제 API 요청')}
+          />
+        </div>
+      </Popover.Content>
+    </Popover.Root>
+  );
+}

--- a/packages/design-system/src/components/index.ts
+++ b/packages/design-system/src/components/index.ts
@@ -11,6 +11,7 @@ export { default as NoResult } from './NoResult';
 export { default as NotificationCard } from './NotificationCard';
 export { default as OwnerBadge } from './OwnerBadge';
 export { default as Pagination } from './Pagination';
+export * from './popover';
 export { default as ProfileImageInput } from './ProfileImageInput';
 export { default as RadioGroup } from './RadioGroup/RadioGroup';
 export { default as ReservationCard } from './ReservationCard';

--- a/packages/design-system/src/components/popover/PopoverContent.tsx
+++ b/packages/design-system/src/components/popover/PopoverContent.tsx
@@ -78,7 +78,7 @@ function PopoverContent({
           visibility: contentSize.width ? 'visible' : 'hidden', // Popover.Content의 위치가 계산되기 전에는 화면에 보이지 않도록
         }}
       >
-        <div className='cursor-pointer'>{children}</div>
+        {children}
       </div>
     </Portal>
     // Trigger도 Overlay 위쪽으로 올라와야 하면 아래 내용 사용 + 상대적 popoverPostion 수정 (relative div가 바뀜)

--- a/packages/design-system/src/components/popover/PopoverTrigger.tsx
+++ b/packages/design-system/src/components/popover/PopoverTrigger.tsx
@@ -28,12 +28,16 @@ export interface PopoverTriggerProps extends BaseProp {
  * ```
  */
 function PopoverTrigger({ children, className, asChild = false }: PopoverTriggerProps) {
-  const { triggerRef, open, setOpen } = usePopoverContext();
+  const { isControlled, triggerRef, open, setOpen } = usePopoverContext();
   // Trigger도 Overlay 위쪽으로 올라와야 하면 아래 overlayClass 사용
   // const zIndex = open && 'z-[910]';
   // const overlayClass = twMerge('relative w-full', zIndex);
 
-  const handleClick = () => setOpen(!open);
+  const handleClick = () => {
+    if (!isControlled) {
+      setOpen(!open);
+    }
+  };
 
   // asChild가 true면 Slot을 사용, false면 button 사용
   if (asChild) {
@@ -55,7 +59,7 @@ function PopoverTrigger({ children, className, asChild = false }: PopoverTrigger
 
   return (
     <div ref={triggerRef} className='relative w-full'>
-      <button className={twMerge('w-full cursor-pointer', className)} onClick={() => setOpen(!open)}>
+      <button className={twMerge('w-full cursor-pointer', className)} onClick={handleClick}>
         {children}
       </button>
     </div>

--- a/packages/design-system/src/components/popover/types/index.ts
+++ b/packages/design-system/src/components/popover/types/index.ts
@@ -18,7 +18,10 @@ export type Position =
   | 'fixed-center-right'
   | 'fixed-bottom-left'
   | 'fixed-bottom-center'
-  | 'fixed-bottom-right';
+  | 'fixed-bottom-right'
+  | 'corner-bottom-left'
+  | 'bottom-right'
+  | 'bottom-center';
 
 /**
  * @description Popover.Content의 크기 (px 단위)

--- a/packages/design-system/src/components/popover/types/index.ts
+++ b/packages/design-system/src/components/popover/types/index.ts
@@ -53,6 +53,8 @@ export interface PopoverContextType {
   direction: Position;
   /** Trigger 요소의 너비 값 */
   triggerWidth: number | null;
+  /** Controlled 여부 */
+  isControlled: boolean;
 }
 
 /**

--- a/packages/design-system/src/components/popover/utils/popoverPosition.ts
+++ b/packages/design-system/src/components/popover/utils/popoverPosition.ts
@@ -80,6 +80,21 @@ export function getPopoverPosition(rect: DOMRect, position: Position, contentSiz
         top: viewportHeight - contentSize.height,
         left: viewportWidth - contentSize.width,
       };
+    case 'corner-bottom-left':
+      return {
+        top: rect.bottom + scrollY,
+        left: rect.left + scrollX - contentSize.width,
+      };
+    case 'bottom-right':
+      return {
+        top: rect.bottom + scrollY,
+        left: rect.right + scrollX - contentSize.width,
+      };
+    case 'bottom-center':
+      return {
+        top: rect.bottom + scrollY,
+        left: (window.innerWidth - contentSize.width) / 2,
+      };
     default:
       return {
         top: rect.bottom + scrollY,

--- a/packages/design-system/src/pages/PopoverDoc.tsx
+++ b/packages/design-system/src/pages/PopoverDoc.tsx
@@ -1,3 +1,6 @@
+import { useState } from 'react';
+
+import { Button } from '@/components';
 import { Popover } from '@/components/popover';
 import Playground from '@/layouts/Playground';
 
@@ -13,6 +16,8 @@ const code = `
 `;
 
 export default function PopoverDoc() {
+  const [open, setOpen] = useState(false);
+
   return (
     <>
       <DocTemplate
@@ -57,6 +62,8 @@ Slot을 사용하기 위해서는 asChild로 명시적으로 활성화해주어�
 | children     | \`ReactNode\`                    | \`Trigger\`, \`Content\` 등의 하위 요소를 포함해야 합니다. |
 | direction    | \`'top', 'bottom', 'left', 'right', 'fixed-top-left', 'fixed-top-center' , 'fixed-top-right' , 'fixed-center-left' , 'fixed-center-center' , 'fixed-center-right' , 'fixed-bottom-left' , 'fixed-bottom-center' , 'fixed-bottom-right'\` | 콘텐츠가 나타날 방향으로, 기본값은 \`bottom\`입니다. \`fixed-\`가 붙으면 현재 뷰포트 기준(절대적), 없으면 Trigger 기준(상대적)으로 위치합니다.           |
 | className    | \`string?\`                      | 스타일 확장용 className으로, Popover의 전체적인 크기를 조정합니다. (ex. Popover가 w-300이라면 Trigger의 크기도 w-300이며, Content의 matchTriggerWidth=true시 Content도 w-300입니다.)               |
+| open          | \`boolean?\`                                                                                                                                           | Controlled 모드로 사용할 때 Popover의 열림 상태를 외부에서 제어합니다.                                                                                                       |
+| onOpenChange  | \`(open: boolean) => void\`                                                                                                                            | Controlled 모드일 때 Popover의 열림 상태가 변경될 경우 호출되는 콜백입니다.                                                                                                   |
 
 ---
 
@@ -111,6 +118,15 @@ Slot을 사용하기 위해서는 asChild로 명시적으로 활성화해주어�
           </Popover.Root>
         ))}
       </div>
+
+      {/* Controlled Popover */}
+      <Popover.Root className='w-300' direction='bottom' open={open} onOpenChange={setOpen}>
+        <Popover.Trigger className='rounded bg-gray-100 px-4 py-2'>
+          외부에서 Popover의 상태를 관리해보세요.
+        </Popover.Trigger>
+        <Popover.Content className='rounded bg-white p-4 shadow'>Controlled Popover</Popover.Content>
+      </Popover.Root>
+      <Button onClick={() => setOpen((prev) => !prev)}>Popover Toggle</Button>
 
       {/* Playground */}
       <div className='mt-24'>


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- #112

## 📌 작업 내용
<!-- 해당 PR의 변경 사항을 자세하게 적어주세요.-->

1. 알림 Popover UI를 구현했습니다. → `NotificationPopover`
    - PC와 태블릿에서는 알림 아이콘 아래에 팝오버가 뜨고, 모바일에서는 알림 아이콘 아래와 화면 중앙에 창이 뜹니다.
    - 창의 너비는 모든 반응형에서 300px 고정이며, 높이 또한 일정 높이로 고정시켜 두어 스크롤이 가능하도록 했습니다.
2. **Popover에 제어 방식을 추가했습니다. (기존은 비제어 방식)**
3. Popover가 뜨는 위치를 추가했습니다.
    - `bottom-center` : Trigger 기준 하단이자, 화면의 중앙에 위치합니다.
    - `bottom-right`: 트리거 아래에서 트리거와 우측정렬됩니다.
    - `corner-bottom-left` : 트리거의 왼쪽 아래 모서리에 위치합니다.

## ✅ 체크리스트

- [x] PR 하기 전에 이슈에서 빼먹은건 없는지 확인했습니다
  - [x] 라벨 및 마일스톤을 사이드 탭에서 등록했습니다.
- [x] PR을 보내는 브랜치가 올바른지 확인했습니다.
- [x] 팀원들이 리뷰하기 쉽도록 설명을 자세하게 작성했습니다.
- [x] 변경사항을 충분히 테스트 했습니다.
- [x] (함수를 구현 했을 때) JSDoc을 양식에 맞춰서 작성했습니다.
- [x] 컨벤션에 맞게 구현했습니다.

## 📷 UI 변경 사항 (선택)
<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->

![알림 팝오버 UI](https://github.com/user-attachments/assets/d88d03d2-7c0d-47d5-ba18-72fdd2642342)


## ❓무슨 문제가 발생했나요? (선택)

알림 Popover가 켜지면 알림 아이콘의 색상이 변경되어야 합니다.
이를 위해선 Popover의 열림/닫힘 상태를 외부에서도 알 수 있어야 하는데, 기존 Popover는 비제어 방식으로 구현되어 있어 외부에서 Popover의 상태를 알 수 없었습니다.

따라서 Popover에 제어 방식을 추가했습니다. (기존처럼 비제어 방식으로 사용해도 문제 없습니다.)
하지만 Popover를 제어 방식으로 사용하려면, 더이상 Trigger가 작동하지 않기 때문에, 외부에서 열림/닫힘을 직접 조정해야 합니다.

기존에 여러 번 문의 주셨던 Select에서 항목을 선택 후 자동으로 창이 닫히는 부분도,
Popover가 제어 방식도 지원하게 되면서 수정할 수 있으므로, 빠르게 반영하여 PR 올리겠습니다!

## 💬 기타 참고 사항 (선택)
<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->

-
