### PR TITLE
내 정보 페이지 API 연결

### DIFF
--- a/apps/what-today/src/apis/auth.ts
+++ b/apps/what-today/src/apis/auth.ts
@@ -41,12 +41,13 @@ export const patchMyProfile = (
   newPassword?: string,
 ) => {
   const safeNickname = nickname?.trim();
-  const safeImageUrl = profileImageUrl === null ? null : profileImageUrl?.trim() || undefined;
   const safePassword = newPassword?.trim();
 
   const body = {
     ...(safeNickname && { nickname: safeNickname }),
-    profileImageUrl: safeImageUrl === '' ? null : safeImageUrl,
+    ...(profileImageUrl !== undefined && {
+      profileImageUrl: profileImageUrl === null ? null : profileImageUrl?.trim() || null,
+    }),
     ...(safePassword && { newPassword: safePassword }),
   };
 
@@ -55,11 +56,13 @@ export const patchMyProfile = (
 
 /**
  * @description 프로필 이미지 url 생성
+ *
+ * @param profileImageFile 업로드할 프로필 이미지 파일
  * @returns 프로필 이미지 url (string)
  */
-export const postProfileImageUrl = (profileImageUrl: File) => {
+export const postProfileImageUrl = (profileImageFile: File) => {
   const formData = new FormData();
-  formData.append('image', profileImageUrl);
+  formData.append('image', profileImageFile);
 
   return axiosInstance.post('users/me/image', formData, {
     headers: {

--- a/apps/what-today/src/apis/auth.ts
+++ b/apps/what-today/src/apis/auth.ts
@@ -30,3 +30,40 @@ export const signUpWithKakao = (code: string) => {
     token: code,
   });
 };
+
+/**
+ * @description 내 정보 수정 PATCH
+ * @returns 변경된 user
+ */
+export const patchMyProfile = (
+  nickname?: string,
+  profileImageUrl?: string | null | undefined,
+  newPassword?: string,
+) => {
+  const safeNickname = nickname?.trim();
+  const safeImageUrl = profileImageUrl === null ? null : profileImageUrl?.trim() || undefined;
+  const safePassword = newPassword?.trim();
+
+  const body = {
+    ...(safeNickname && { nickname: safeNickname }),
+    profileImageUrl: safeImageUrl === '' ? null : safeImageUrl,
+    ...(safePassword && { newPassword: safePassword }),
+  };
+
+  return axiosInstance.patch('users/me', body);
+};
+
+/**
+ * @description 프로필 이미지 url 생성
+ * @returns 프로필 이미지 url (string)
+ */
+export const postProfileImageUrl = (profileImageUrl: File) => {
+  const formData = new FormData();
+  formData.append('image', profileImageUrl);
+
+  return axiosInstance.post('users/me/image', formData, {
+    headers: {
+      'Content-Type': 'multipart/form-data',
+    },
+  });
+};

--- a/apps/what-today/src/components/Header.tsx
+++ b/apps/what-today/src/components/Header.tsx
@@ -35,9 +35,13 @@ export default function Header() {
 
           <div className='mx-12 h-16 w-px bg-gray-100' />
 
-          <Link className='flex items-center gap-8 hover:opacity-60' to='/mypage'>
+          <Link className='flex items-center gap-8 hover:opacity-60' to='/mypage/edit-profile'>
             {user?.profileImageUrl ? (
-              <img alt='프로필 이미지' className='size-24 rounded-full object-cover' src={user.profileImageUrl} />
+              <img
+                alt='프로필 이미지'
+                className='size-24 rounded-full border border-gray-50 object-cover'
+                src={user.profileImageUrl}
+              />
             ) : (
               <ProfileLogo className='size-24' />
             )}

--- a/apps/what-today/src/components/Header.tsx
+++ b/apps/what-today/src/components/Header.tsx
@@ -9,7 +9,7 @@ export default function Header() {
   const { user, isLoggedIn } = useWhatTodayStore();
 
   return (
-    <header className='relative z-50 flex w-full justify-between py-16'>
+    <div className='relative z-50 flex w-full justify-between py-16'>
       <Link className='flex items-center gap-8' to='/'>
         <ImageLogo className='size-24' />
         <TextLogo className='hidden h-fit w-65 sm:block' />
@@ -60,6 +60,6 @@ export default function Header() {
           </Link>
         </div>
       )}
-    </header>
+    </div>
   );
 }

--- a/apps/what-today/src/components/MypageSidebar.tsx
+++ b/apps/what-today/src/components/MypageSidebar.tsx
@@ -10,8 +10,6 @@ import {
 import { Link, useLocation } from 'react-router-dom';
 import { twMerge } from 'tailwind-merge';
 
-import { useWhatTodayStore } from '@/stores';
-
 interface MypageSidebarProps {
   /**
    * 사용자 프로필 이미지 URL
@@ -50,7 +48,7 @@ interface MypageSidebarProps {
  */
 export default function MypageSidebar({ profileImgUrl, onLogoutClick, onClick, isOpen }: MypageSidebarProps) {
   const location = useLocation();
-  const { user } = useWhatTodayStore();
+
   /**
    * 사이드바에 표시할 고정 메뉴 항목 목록
    * 각 항목은 라벨, 아이콘 컴포넌트, 이동 경로로 구성됩니다.
@@ -81,11 +79,11 @@ export default function MypageSidebar({ profileImgUrl, onLogoutClick, onClick, i
           'md:flex',
         )}
       >
-        {user?.profileImageUrl ? (
+        {profileImgUrl ? (
           <img
             alt='프로필 이미지'
             className='bg-white-100 size-120 rounded-full border border-gray-50 object-cover'
-            src={user?.profileImageUrl ?? ''}
+            src={profileImgUrl}
           />
         ) : (
           <ProfileLogo className='rounded-full' size={120} />

--- a/apps/what-today/src/components/MypageSidebar.tsx
+++ b/apps/what-today/src/components/MypageSidebar.tsx
@@ -64,7 +64,7 @@ export default function MypageSidebar({ profileImgUrl, onLogoutClick, onClick, i
     <nav
       className={twMerge(
         // 공통 스타일
-        'fixed z-50 max-w-200 min-w-200 rounded-xl border border-gray-50 bg-white shadow-[0px_4px_24px_rgba(156,180,202,0.2)] transition duration-300 md:static md:h-474 xl:w-280',
+        'fixed z-50 max-w-200 min-w-200 rounded-xl border border-gray-50 bg-white shadow-[0px_4px_24px_rgba(156,180,202,0.2)] transition duration-300 md:static md:h-fit xl:w-280',
         // 모바일에서 Drawer 위치
         isOpen ? 'h-474 translate-x-0' : 'bg-primary-100 border-primary-100 h-50 -translate-x-full',
         'md:translate-x-0',

--- a/apps/what-today/src/components/MypageSidebar.tsx
+++ b/apps/what-today/src/components/MypageSidebar.tsx
@@ -10,6 +10,8 @@ import {
 import { Link, useLocation } from 'react-router-dom';
 import { twMerge } from 'tailwind-merge';
 
+import { useWhatTodayStore } from '@/stores';
+
 interface MypageSidebarProps {
   /**
    * 사용자 프로필 이미지 URL
@@ -48,6 +50,7 @@ interface MypageSidebarProps {
  */
 export default function MypageSidebar({ profileImgUrl, onLogoutClick, onClick, isOpen }: MypageSidebarProps) {
   const location = useLocation();
+  const { user } = useWhatTodayStore();
   /**
    * 사이드바에 표시할 고정 메뉴 항목 목록
    * 각 항목은 라벨, 아이콘 컴포넌트, 이동 경로로 구성됩니다.
@@ -63,7 +66,7 @@ export default function MypageSidebar({ profileImgUrl, onLogoutClick, onClick, i
     <nav
       className={twMerge(
         // 공통 스타일
-        'fixed z-50 w-180 rounded-xl border border-gray-50 bg-white shadow-[0px_4px_24px_rgba(156,180,202,0.2)] transition duration-300 md:static md:h-474 xl:w-280',
+        'fixed z-50 max-w-200 min-w-200 rounded-xl border border-gray-50 bg-white shadow-[0px_4px_24px_rgba(156,180,202,0.2)] transition duration-300 md:static md:h-474 xl:w-280',
         // 모바일에서 Drawer 위치
         isOpen ? 'h-474 translate-x-0' : 'bg-primary-100 border-primary-100 h-50 -translate-x-full',
         'md:translate-x-0',
@@ -78,8 +81,12 @@ export default function MypageSidebar({ profileImgUrl, onLogoutClick, onClick, i
           'md:flex',
         )}
       >
-        {profileImgUrl ? (
-          <img alt='프로필 이미지' className='bg-primary-100 size-120 rounded-full' src={profileImgUrl} />
+        {user?.profileImageUrl ? (
+          <img
+            alt='프로필 이미지'
+            className='bg-white-100 size-120 rounded-full border border-gray-50 object-cover'
+            src={user?.profileImageUrl ?? ''}
+          />
         ) : (
           <ProfileLogo className='rounded-full' size={120} />
         )}

--- a/apps/what-today/src/components/auth/PasswordConfirmInput.tsx
+++ b/apps/what-today/src/components/auth/PasswordConfirmInput.tsx
@@ -8,7 +8,7 @@ function PasswordConfirmInput({ value, onChange }: InputProps) {
 
   return (
     <Input.Root className='w-full'>
-      <Input.Label>비밀번호</Input.Label>
+      <Input.Label>비밀번호 확인</Input.Label>
       <Input.Wrapper>
         <Input.Field
           autoComplete='off'

--- a/apps/what-today/src/layouts/Mypage.tsx
+++ b/apps/what-today/src/layouts/Mypage.tsx
@@ -4,12 +4,14 @@ import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 
 import MypageSidebar from '@/components/MypageSidebar';
 import useAuth from '@/hooks/useAuth';
+import { useWhatTodayStore } from '@/stores';
 
 export default function MyPageLayout() {
   const location = useLocation();
   const navigate = useNavigate();
   const [isSidebarOpen, setSidebarOpen] = useState(false);
   const { logoutUser } = useAuth();
+  const { user } = useWhatTodayStore();
   const { toast } = useToast();
 
   const handleLogout = () => {
@@ -34,6 +36,7 @@ export default function MyPageLayout() {
       )}
       <MypageSidebar
         isOpen={isSidebarOpen}
+        profileImgUrl={user?.profileImageUrl ?? ''}
         onClick={() => setSidebarOpen((prev) => !prev)}
         onLogoutClick={handleLogout}
       />

--- a/apps/what-today/src/pages/mypage/edit-profile/index.tsx
+++ b/apps/what-today/src/pages/mypage/edit-profile/index.tsx
@@ -17,10 +17,20 @@ import { useWhatTodayStore } from '@/stores';
  * @returns {Promise<File>} - Blob을 감싼 File 객체
  */
 const stringToFile = async (url: string, filename = 'image.jpg'): Promise<File> => {
-  const res = await fetch(url);
-  const blob = await res.blob();
-  const contentType = blob.type || 'image/jpeg';
-  return new File([blob], filename, { type: contentType });
+  try {
+    const res = await fetch(url);
+    if (!res.ok) {
+      throw new Error(`이미지 다운로드 실패: ${res.status} ${res.statusText}`);
+    }
+    const blob = await res.blob();
+    if (blob.size === 0) {
+      throw new Error('빈 이미지 파일입니다.');
+    }
+    const contentType = blob.type || 'image/jpeg';
+    return new File([blob], filename, { type: contentType });
+  } catch (error) {
+    throw new Error('이미지 변환 중 오류가 발생했습니다.');
+  }
 };
 
 export default function EditProfilePage() {

--- a/apps/what-today/src/pages/mypage/edit-profile/index.tsx
+++ b/apps/what-today/src/pages/mypage/edit-profile/index.tsx
@@ -6,6 +6,7 @@ import { patchMyProfile, postProfileImageUrl } from '@/apis/auth';
 import NicknameInput from '@/components/auth/NicknameInput';
 import PasswordConfirmInput from '@/components/auth/PasswordConfirmInput';
 import PasswordInput from '@/components/auth/PasswordInput';
+import useAuth from '@/hooks/useAuth';
 import { useWhatTodayStore } from '@/stores';
 
 /**
@@ -25,6 +26,8 @@ const stringToFile = async (url: string, filename = 'image.jpg'): Promise<File> 
 export default function EditProfilePage() {
   const navigate = useNavigate();
   const { user, setUser } = useWhatTodayStore();
+  const { logoutUser } = useAuth();
+
   const { toast } = useToast();
   const [isEditProfileLoading] = useState(false);
   const [profileImage, setProfileImage] = useState<string>(user?.profileImageUrl ?? '');
@@ -47,6 +50,19 @@ export default function EditProfilePage() {
     setPassword('');
     setPasswordConfirm('');
     setProfileImage(userData?.profileImageUrl ?? '');
+  };
+
+  /**
+   * @description 비밀번호가 수정된 경우에만 로그아웃 후 재로그인을 유도합니다.
+   */
+  const handleLogout = () => {
+    logoutUser();
+    navigate('/login');
+    toast({
+      title: '내 정보 변경 성공',
+      description: '비밀번호가 변경되었습니다. 다시 로그인해 주세요.',
+      type: 'success',
+    });
   };
 
   /**
@@ -79,8 +95,19 @@ export default function EditProfilePage() {
       }
 
       const response = await patchMyProfile(nickname, uploadedImageUrl, password);
+
+      toast({
+        title: '내 정보 변경 성공',
+        description: '프로필이 성공적으로 업데이트되었습니다.',
+        type: 'success',
+      });
       setUser(response.data);
       resetForm(response.data);
+
+      // 비밀번호가 수정되었다면 로그아웃 후 로그인 페이지로 이동 (재로그인 유도)
+      if (password.length > 0) {
+        handleLogout();
+      }
     } catch (error) {
       const message = error instanceof Error ? error.message : '프로필 수정에 실패했습니다.';
       toast({

--- a/apps/what-today/src/pages/mypage/edit-profile/index.tsx
+++ b/apps/what-today/src/pages/mypage/edit-profile/index.tsx
@@ -1,47 +1,96 @@
-import { Button, ChevronIcon, ProfileImageInput } from '@what-today/design-system';
+import { Button, ChevronIcon, ProfileImageInput, useToast } from '@what-today/design-system';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import { patchMyProfile, postProfileImageUrl } from '@/apis/auth';
 import NicknameInput from '@/components/auth/NicknameInput';
 import PasswordConfirmInput from '@/components/auth/PasswordConfirmInput';
 import PasswordInput from '@/components/auth/PasswordInput';
 import { useWhatTodayStore } from '@/stores';
 
+const stringToFile = async (url: string, filename = 'image.jpg'): Promise<File> => {
+  const res = await fetch(url);
+  const blob = await res.blob();
+  const contentType = blob.type || 'image/jpeg';
+  return new File([blob], filename, { type: contentType });
+};
+
 export default function EditProfilePage() {
   const navigate = useNavigate();
-  const { user } = useWhatTodayStore();
+  const { user, setUser } = useWhatTodayStore();
+  const { toast } = useToast();
   const [isEditProfileLoading] = useState(false);
   const [profileImage, setProfileImage] = useState<string>(user?.profileImageUrl ?? '');
   const [nickname, setNickname] = useState(user?.nickname ?? '');
   const [password, setPassword] = useState('');
   const [passwordConfirm, setPasswordConfirm] = useState('');
 
-  const handleBackBtnClick = () => {
-    navigate(-1);
+  const handleNavigateToMypage = () => {
+    navigate('/mypage');
+  };
+
+  const resetForm = (userData = user) => {
+    setNickname(userData?.nickname ?? '');
+    setPassword('');
+    setPasswordConfirm('');
+    setProfileImage(userData?.profileImageUrl ?? '');
+  };
+
+  const handleReset = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    resetForm();
+  };
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    try {
+      let uploadedImageUrl: string | null | undefined = undefined;
+      const isBlobUrl = profileImage.startsWith('blob:');
+      const isReset = profileImage === '';
+      const isOriginalImage = profileImage === user?.profileImageUrl;
+
+      if (isBlobUrl) {
+        const file = await stringToFile(profileImage, 'profile.jpg');
+        const imageUploadRes = await postProfileImageUrl(file);
+        uploadedImageUrl = imageUploadRes.data.profileImageUrl;
+      } else if (isReset) {
+        uploadedImageUrl = null;
+      } else if (!isOriginalImage) {
+        uploadedImageUrl = profileImage;
+      }
+
+      const response = await patchMyProfile(nickname, uploadedImageUrl, password);
+      setUser(response.data);
+      resetForm(response.data);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : '프로필 수정에 실패했습니다.';
+      toast({
+        title: '프로필 수정 실패',
+        description: message,
+        type: 'error',
+      });
+    }
   };
 
   return (
     <div className='flex flex-col gap-12 text-gray-900'>
       <div className='flex items-center gap-4'>
-        <Button className='h-fit w-fit' variant='none' onClick={handleBackBtnClick}>
+        <Button className='h-fit w-fit' variant='none' onClick={handleNavigateToMypage}>
           <ChevronIcon color='var(--color-gray-300)' direction='left' />
         </Button>
         <h1 className='text-xl font-bold'>내 정보</h1>
       </div>
       <form
         className='flex w-full flex-col items-center justify-center gap-32'
-        onReset={() => {
-          setNickname(user?.nickname ?? '');
-          setPassword('');
-          setPasswordConfirm('');
-          setProfileImage(user?.profileImageUrl ?? '');
-        }}
-        onSubmit={(e) => {
-          e.preventDefault();
-        }}
+        onReset={handleReset}
+        onSubmit={handleSubmit}
       >
         <div className='flex w-full flex-col gap-12'>
-          <ProfileImageInput src={profileImage} onChange={(value) => setProfileImage(value)} />
+          <ProfileImageInput
+            initial={user?.profileImageUrl ?? ''}
+            src={profileImage}
+            onChange={(value) => setProfileImage(value)}
+          />
           <NicknameInput value={nickname} onChange={(e) => setNickname(e.target.value)} />
           <PasswordInput value={password} onChange={(e) => setPassword(e.target.value)} />
           {password.length > 0 && (
@@ -49,9 +98,9 @@ export default function EditProfilePage() {
           )}
         </div>
 
-        <div className='flex w-full max-w-640 gap-12'>
+        <div className='flex w-full max-w-640 justify-center gap-12'>
           <Button
-            className='h-fit flex-1 rounded-xl py-10 font-normal'
+            className='h-fit w-auto rounded-xl py-10 font-normal'
             loading={isEditProfileLoading}
             size='xl'
             type='reset'
@@ -60,7 +109,7 @@ export default function EditProfilePage() {
             취소
           </Button>
           <Button
-            className='h-fit flex-2 rounded-xl py-10 font-normal'
+            className='h-fit w-auto rounded-xl py-10 font-normal'
             loading={isEditProfileLoading}
             size='xl'
             type='submit'

--- a/apps/what-today/src/pages/mypage/edit-profile/index.tsx
+++ b/apps/what-today/src/pages/mypage/edit-profile/index.tsx
@@ -8,6 +8,13 @@ import PasswordConfirmInput from '@/components/auth/PasswordConfirmInput';
 import PasswordInput from '@/components/auth/PasswordInput';
 import { useWhatTodayStore } from '@/stores';
 
+/**
+ * @description 주어진 이미지 URL을 fetch하여 Blob으로 변환한 뒤 File 객체로 반환합니다.
+ *
+ * @param {string} url - 변환할 이미지의 URL
+ * @param {string} [filename='image.jpg'] - 생성될 File 객체의 파일명 (기본값: 'image.jpg')
+ * @returns {Promise<File>} - Blob을 감싼 File 객체
+ */
 const stringToFile = async (url: string, filename = 'image.jpg'): Promise<File> => {
   const res = await fetch(url);
   const blob = await res.blob();
@@ -25,10 +32,16 @@ export default function EditProfilePage() {
   const [password, setPassword] = useState('');
   const [passwordConfirm, setPasswordConfirm] = useState('');
 
+  /**
+   * @description 뒤로가기 버튼으로 리다이렉트할 페이지입니다.
+   */
   const handleNavigateToMypage = () => {
     navigate('/mypage');
   };
 
+  /**
+   * @description 취소 버튼을 누르거나, 내 정보 수정에 성공할 때 사용할 폼 초기화 함수입니다.
+   */
   const resetForm = (userData = user) => {
     setNickname(userData?.nickname ?? '');
     setPassword('');
@@ -36,11 +49,17 @@ export default function EditProfilePage() {
     setProfileImage(userData?.profileImageUrl ?? '');
   };
 
+  /**
+   * @description 취소 버튼을 눌렀을 때 입력된 폼을 초기화 합니다.
+   */
   const handleReset = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     resetForm();
   };
 
+  /**
+   * @description 프로필 사진 or 닉네임 or 비밀번호를 수정하는 API를 요청합니다. 실패시 에러 토스트 메시지를 보여줍니다.
+   */
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     try {

--- a/packages/design-system/src/components/ProfileImageInput.tsx
+++ b/packages/design-system/src/components/ProfileImageInput.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useState } from 'react';
 
 interface ProfileImageInputProps {
   src: string;
+  initial?: string;
   onChange: (value: string) => void;
 }
 
@@ -64,11 +65,12 @@ export function DeleteButton({ onDelete }: { onDelete: () => void }) {
  * - 기본 이미지 상태에서는 삭제 버튼이 숨겨지고 "프로필 이미지 변경" 문구가 나타납니다.
  *
  * @component
- * @param {string} src - 초기 프로필 이미지 URL (서버에서 내려온 값)
+ * @param {string} src - 선택된 프로필 이미지 URL
+ * @param {string} initial - 초기 프로필 이미지 URL (서버에서 내려온 값)
  * @param {(value: string) => void} onChange - 이미지가 변경되었을 때 호출되는 콜백 함수. base64 string 또는 URL을 인자로 받습니다.
  */
-export default function ProfileImageInput({ src, onChange }: ProfileImageInputProps) {
-  const [initialSrc] = useState(src);
+export default function ProfileImageInput({ src, initial = src, onChange }: ProfileImageInputProps) {
+  const [initialSrc, setInitialSrc] = useState(initial);
   const [previewUrl, setPreviewUrl] = useState<string>(src);
 
   const isDefaultImage = previewUrl === '';
@@ -100,17 +102,27 @@ export default function ProfileImageInput({ src, onChange }: ProfileImageInputPr
   };
 
   const handleDelete = () => {
-    if (initialSrc) setPreviewUrl(initialSrc);
-    else setPreviewUrl('');
+    if (initialSrc) {
+      setPreviewUrl(initialSrc);
+      onChange(initialSrc);
+    } else {
+      setPreviewUrl('');
+      onChange('');
+    }
   };
 
   const handleReset = () => {
     setPreviewUrl('');
+    onChange('');
   };
 
   useEffect(() => {
     setPreviewUrl(src);
   }, [src]);
+
+  useEffect(() => {
+    setInitialSrc(initial);
+  }, [initial]);
 
   useEffect(() => {
     return () => {

--- a/packages/design-system/src/pages/ProfileImageInputDoc.tsx
+++ b/packages/design-system/src/pages/ProfileImageInputDoc.tsx
@@ -68,7 +68,8 @@ blob 방식은 브라우저 메모리를 사용하기 때문에 빠르고 가볍
         propsDescription={`
 | 이름 | 타입 | 설명 |
 |------|------|------|
-| src | \`string\` | 초기 프로필 이미지 URL (서버에서 내려온 값) |
+| src | \`string\` | 선택된 프로필 이미지 URL |
+| initial | \`string\` | 초기 프로필 이미지 URL (서버에서 내려온 값) |
 | onChange | \`(value: string) => void\` | 이미지가 변경되었을 때 호출되는 콜백 함수 |
 `}
         title='ProfileImageInput'


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- #108

## 📌 작업 내용
<!-- 해당 PR의 변경 사항을 자세하게 적어주세요.-->

- 내 정보 페이지의 API를 연결했습니다.
    ```
    1. 프로필 사진 변경이 가능합니다.
    2. 닉네임 변경이 가능합니다.
    3. 비밀번호 변경이 가능합니다.
    → 한 가지만 변경할 수 있습니다.
    ````
- 외부에서 선택된 프로필 이미지의 값 상태와, 현재 프로필 사진의 정보(`initial`)을 `ProfileImageInput`에 전달 & 동기화하는 부분을 추가했습니다.
- 로그인 / 회원가입과 함께 zod + react hook form + tanstack query를 사용해 리팩토링할 예정입니다.  
   (동일한 입력폼을 재사용하기 때문입니다.)
- `PasswordConfirmInput`의 오타를 수정했습니다. (비밀번호 → 비밀번호 확인)
- `MypageSidebar`
    - `MypageSidebar`의 크기를 200px로 고정했습니다.
    - `MypageSidebar`에도 프로필 사진을 반영했습니다.

## ✅ 체크리스트

- [x] PR 하기 전에 이슈에서 빼먹은건 없는지 확인했습니다
  - [x] 라벨 및 마일스톤을 사이드 탭에서 등록했습니다.
- [x] PR을 보내는 브랜치가 올바른지 확인했습니다.
- [x] 팀원들이 리뷰하기 쉽도록 설명을 자세하게 작성했습니다.
- [x] 변경사항을 충분히 테스트 했습니다.
- [x] (함수를 구현 했을 때) JSDoc을 양식에 맞춰서 작성했습니다.
- [x] 컨벤션에 맞게 구현했습니다.

## 📷 UI 변경 사항 (선택)
<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->

![내정보수정API연결](https://github.com/user-attachments/assets/ceb6c6e4-1787-499f-a2c0-d070fcbd25a9)

## ❓무슨 문제가 발생했나요? (선택)

-

## 💬 기타 참고 사항 (선택)
<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **신규 기능**
  * 마이페이지에서 닉네임, 비밀번호, 프로필 이미지 수정 및 이미지 업로드 기능이 추가되었습니다.
  * 프로필 이미지 업로드 및 프로필 정보 수정 API가 도입되었습니다.

* **버그 수정**
  * 프로필 이미지 삭제 및 초기화 시 외부 상태와의 동기화가 개선되었습니다.

* **UI/스타일**
  * 헤더와 마이페이지 사이드바의 프로필 이미지에 테두리 및 스타일이 적용되었습니다.
  * 마이페이지 사이드바의 레이아웃과 크기가 조정되었습니다.
  * 프로필 이미지 입력 컴포넌트에 초기 이미지와 선택 이미지가 명확히 구분되어 표시됩니다.

* **문서화**
  * 프로필 이미지 입력 컴포넌트의 props 설명이 명확하게 업데이트되었습니다.

* **기타**
  * 비밀번호 입력 필드 라벨이 "비밀번호"에서 "비밀번호 확인"으로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->