### PR TITLE
예약 정보 컴포넌트 UI 구현

### DIFF
--- a/apps/what-today/src/apis/myActivities.ts
+++ b/apps/what-today/src/apis/myActivities.ts
@@ -1,7 +1,13 @@
 import {
-  type ActivityReservationParam,
-  type ActivityReservationResponse,
-  activityReservationResponseSchema,
+  type dailyScheduleParam,
+  type dailyScheduleResponse,
+  dailyScheduleResponseSchema,
+  type monthlyScheduleParam,
+  type monthlyScheduleResponse,
+  monthlyScheduleResponseSchema,
+  type timeSlotReservationParam,
+  type timeSlotReservationResponse,
+  timeSlotReservationResponseSchema,
 } from '@/schemas/myActivities';
 import { type myActivitiesParam, type myActivitiesResponse, myActivitiesResponseSchema } from '@/schemas/myActivities';
 
@@ -12,10 +18,26 @@ export const getMyActivities = async (params?: myActivitiesParam): Promise<myAct
   return myActivitiesResponseSchema.parse(response.data);
 };
 
-export const getMonthlyReservations = async (
+export const getMonthlySchedule = async (
   activityId: number,
-  params: ActivityReservationParam,
-): Promise<ActivityReservationResponse> => {
+  params: monthlyScheduleParam,
+): Promise<monthlyScheduleResponse> => {
   const response = await axiosInstance.get(`/my-activities/${activityId}/reservation-dashboard`, { params });
-  return activityReservationResponseSchema.parse(response.data);
+  return monthlyScheduleResponseSchema.parse(response.data);
+};
+
+export const getDailySchedule = async (
+  activityId: number,
+  params: dailyScheduleParam,
+): Promise<dailyScheduleResponse> => {
+  const response = await axiosInstance.get(`/my-activities/${activityId}/reserved-schedule`, { params });
+  return dailyScheduleResponseSchema.parse(response.data);
+};
+
+export const getReservation = async (
+  activityId: number,
+  params: timeSlotReservationParam,
+): Promise<timeSlotReservationResponse> => {
+  const response = await axiosInstance.get(`/my-activities/${activityId}/reservations`, { params });
+  return timeSlotReservationResponseSchema.parse(response.data);
 };

--- a/apps/what-today/src/components/reservations-status/ReservationSheet.tsx
+++ b/apps/what-today/src/components/reservations-status/ReservationSheet.tsx
@@ -1,0 +1,81 @@
+import { Button, Select } from '@what-today/design-system';
+import { useEffect, useState } from 'react';
+import { twMerge } from 'tailwind-merge';
+
+import { getDailySchedule } from '@/apis/myActivities';
+import type { dailyScheduleResponse } from '@/schemas/myActivities';
+
+import ReservationTabPanel from './ReservationTabPanel';
+
+const Tabs = ['신청', '승인', '거절'] as const;
+type Tab = (typeof Tabs)[number];
+
+interface ReservationSheetProps {
+  activityId: number;
+  selectedDate: string;
+}
+export default function ReservationSheet({ activityId, selectedDate }: ReservationSheetProps) {
+  const [selectedTab, setSelectedTab] = useState<Tab>('신청');
+  const [dailyReservation, setDailyReservation] = useState<dailyScheduleResponse>([]);
+  const [loading, setLoading] = useState(true);
+
+  const fetchDailySchedule = async (selectedDate: string) => {
+    try {
+      const result = await getDailySchedule(activityId, { date: selectedDate });
+      setDailyReservation(result);
+    } catch (err) {
+      console.error('내 체험 조회 실패:', err);
+    }
+    setLoading(false);
+  };
+  useEffect(() => {
+    fetchDailySchedule(selectedDate);
+  }, [selectedDate]);
+
+  return (
+    <div className='flex flex-col gap-20 bg-white'>
+      <section className='flex flex-col gap-12'>
+        <h3 className='text-xl font-bold'>25년 7월 24일</h3>
+        <div className='flex text-lg'>
+          {Tabs.map((tab) => {
+            const selectedStyle =
+              selectedTab === tab ? 'border-b-2 border-primary-500 text-primary-500' : 'text-gray-500';
+            return (
+              <Button
+                key={tab}
+                className={twMerge('w-full rounded-none border-b border-gray-100', selectedStyle)}
+                variant='none'
+                onClick={() => setSelectedTab(tab)}
+              >
+                {tab}
+              </Button>
+            );
+          })}
+        </div>
+      </section>
+      <section className='flex flex-col gap-20 md:flex-row'>
+        <div className='flex grow flex-col gap-12'>
+          <h3 className='text-md font-bold'>예약 시간</h3>
+          <Select.Root value={{ value: '시간대별 예약', label: '예약 시간을 선택해주세요' }}>
+            <Select.Trigger className='h-54'>
+              <Select.Value placeholder='예약 시간 선택하기' />
+            </Select.Trigger>
+            <Select.Content>
+              <Select.Group>
+                <Select.Label>시간대별 예약</Select.Label>
+                {dailyReservation.map(({ scheduleId, startTime, endTime }) => {
+                  return (
+                    <Select.Item key={scheduleId} value={String(scheduleId)}>
+                      {startTime}~{endTime}
+                    </Select.Item>
+                  );
+                })}
+              </Select.Group>
+            </Select.Content>
+          </Select.Root>
+        </div>
+        <ReservationTabPanel />
+      </section>
+    </div>
+  );
+}

--- a/apps/what-today/src/components/reservations-status/ReservationTabPanel.tsx
+++ b/apps/what-today/src/components/reservations-status/ReservationTabPanel.tsx
@@ -1,0 +1,13 @@
+import { ReservationInfoCard } from '@what-today/design-system';
+
+export default function ReservationTabPanel() {
+  return (
+    // 추후 api 연결하면 상태에 따라 card 변경 예정
+    <div className='flex grow flex-col gap-12'>
+      <h3 className='text-md font-bold'>예약 내역</h3>
+      <ReservationInfoCard headCount={7} nickname='김지현' ownerStatus='pending' userStatus='pending' />
+      <ReservationInfoCard headCount={7} nickname='김지현' ownerStatus='pending' userStatus='pending' />
+      <ReservationInfoCard headCount={7} nickname='김지현' ownerStatus='pending' userStatus='pending' />
+    </div>
+  );
+}

--- a/apps/what-today/src/pages/mypage/reservations-status/index.tsx
+++ b/apps/what-today/src/pages/mypage/reservations-status/index.tsx
@@ -1,16 +1,18 @@
-import { NoResult, type ReservationStatus, Select } from '@what-today/design-system';
+import { BottomSheet, NoResult, type ReservationStatus, Select } from '@what-today/design-system';
 import dayjs from 'dayjs';
 import { type ReactNode, type SetStateAction, useEffect, useState } from 'react';
 
-import { getMonthlyReservations, getMyActivities } from '@/apis/myActivities';
+import { getMonthlySchedule, getMyActivities } from '@/apis/myActivities';
 import ReservationCalendar from '@/components/reservations-status/ReservationCalendar';
-import type { ActivityReservationResponse, myActivitiesResponse } from '@/schemas/myActivities';
+import ReservationSheet from '@/components/reservations-status/ReservationSheet';
+import type { monthlyScheduleResponse, myActivitiesResponse } from '@/schemas/myActivities';
 
 export default function ReservationsStatusPage() {
-  const [activitiesData, setActivitiesData] = useState<myActivitiesResponse | null>(null);
-  const [reservation, setReservation] = useState<ActivityReservationResponse>([]);
-  const [activitiesLoading, setActivitiesLoading] = useState(true);
-  const [reservationLoading, setReservationLoading] = useState(true);
+  const [bottomSheetOpen, setBottomSheetOpen] = useState(false);
+  const [activityList, setActivityList] = useState<myActivitiesResponse | null>(null);
+  const [monthlyReservation, setMonthlyReservation] = useState<monthlyScheduleResponse>([]);
+  const [monthlyLoading, setMonthlyLoading] = useState(true);
+  const [dailyLoading, setDailyLoading] = useState(true);
 
   const [selectedActivity, setSelectedActivity] = useState<{ value: string; label: ReactNode } | null>(null);
   const [selectedDate, setSelectedDate] = useState('');
@@ -18,7 +20,6 @@ export default function ReservationsStatusPage() {
     year: dayjs().format('YYYY'),
     month: dayjs().format('MM'),
   });
-  console.log(selectedDate); // 임시 설정
 
   const handleValueChange = (value: SetStateAction<{ value: string; label: ReactNode } | null>) => {
     setSelectedActivity(value);
@@ -26,6 +27,7 @@ export default function ReservationsStatusPage() {
 
   const handleDateChange = (date: string) => {
     setSelectedDate(date);
+    setBottomSheetOpen(true);
   };
 
   const handleMonthChange = (year: string, month: string) => {
@@ -36,7 +38,7 @@ export default function ReservationsStatusPage() {
   const fetchMyActivities = async () => {
     try {
       const result = await getMyActivities({ size: 10 });
-      setActivitiesData(result);
+      setActivityList(result);
       if (result.activities.length > 0) {
         const firstActivity = result.activities[0];
         setSelectedActivity({ value: String(firstActivity.id), label: firstActivity.title });
@@ -44,7 +46,7 @@ export default function ReservationsStatusPage() {
     } catch (err) {
       console.error('내 체험 조회 실패:', err);
     }
-    setActivitiesLoading(false);
+    setMonthlyLoading(false);
   };
 
   useEffect(() => {
@@ -53,30 +55,30 @@ export default function ReservationsStatusPage() {
 
   useEffect(() => {
     if (!selectedActivity) return;
-    const fetchReservation = async () => {
+    const fetchMonthlySchedule = async () => {
       try {
-        const result = await getMonthlyReservations(Number(selectedActivity.value), {
+        const result = await getMonthlySchedule(Number(selectedActivity.value), {
           year: viewingMonth.year,
           month: viewingMonth.month,
         });
-        setReservation(result);
+        setMonthlyReservation(result);
       } catch (err) {
         console.error('월별 예약현황 조회 실패:', err);
       }
-      setReservationLoading(false);
+      setDailyLoading(false);
     };
-    fetchReservation();
+    fetchMonthlySchedule();
   }, [selectedActivity, viewingMonth]);
 
-  const reservationMap = reservation.reduce<Record<string, Record<ReservationStatus, number>>>((acc, cur) => {
+  const reservationMap = monthlyReservation.reduce<Record<string, Record<ReservationStatus, number>>>((acc, cur) => {
     acc[cur.date] = cur.reservations;
     return acc;
   }, {});
 
   let content;
-  if (activitiesLoading || reservationLoading) {
+  if (monthlyLoading || dailyLoading) {
     content = <div className='flex justify-center p-40 text-gray-500'>로딩 중...</div>;
-  } else if (activitiesData && activitiesData.activities.length > 0) {
+  } else if (activityList && activityList.activities.length > 0) {
     content = (
       <div className='flex flex-col md:gap-24 xl:gap-30'>
         <section aria-label='체험 선택하기' className='max-w-640'>
@@ -87,8 +89,8 @@ export default function ReservationsStatusPage() {
             <Select.Content>
               <Select.Group>
                 <Select.Label>내 체험 목록</Select.Label>
-                {activitiesData &&
-                  activitiesData.activities.map(({ id, title }) => {
+                {activityList &&
+                  activityList.activities.map(({ id, title }) => {
                     return (
                       <Select.Item key={id} value={String(id)}>
                         {title}
@@ -118,6 +120,13 @@ export default function ReservationsStatusPage() {
 
   return (
     <div className='flex flex-col md:gap-24 xl:gap-30'>
+      <BottomSheet.Root isOpen={bottomSheetOpen} onClose={() => setBottomSheetOpen(false)}>
+        <BottomSheet.Content className='px-24 py-6'>
+          {selectedActivity && selectedDate && (
+            <ReservationSheet activityId={Number(selectedActivity?.value)} selectedDate={selectedDate} />
+          )}
+        </BottomSheet.Content>
+      </BottomSheet.Root>
       <header className='mb-18 flex flex-col gap-10 p-1 md:mb-0'>
         <h1 className='text-xl font-bold text-gray-950'>예약 현황</h1>
         <p className='text-md font-medium text-gray-500'>내 체험에 예약된 내역들을 한 눈에 확인할 수 있습니다.</p>

--- a/apps/what-today/src/schemas/myActivities.ts
+++ b/apps/what-today/src/schemas/myActivities.ts
@@ -3,6 +3,27 @@ import { z } from 'zod';
 import { activitySchema } from './activities';
 
 /**
+ * @description 기본 체험 데이터 유효성을 검사하는 스키마
+ */
+export const reservationSchema = z.object({
+  id: z.number().int().positive(),
+  nickname: z.string(),
+  userId: z.number().int().positive(),
+  teamId: z.string(),
+  activityId: z.number().int().positive(),
+  scheduleId: z.number().int().positive(),
+  status: z.string(),
+  reviewSubmitted: z.boolean(),
+  totalPrice: z.number().int().nonnegative(),
+  headCount: z.number().int().nonnegative(),
+  date: z.string(),
+  startTime: z.string(),
+  endTime: z.string(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+});
+
+/**
  * To server
  * @description 내가 등록한 체험 리스트 조회 요청 시 사용하는 쿼리 파라미터의 유효성을 검사하는 스키마
  */
@@ -25,7 +46,7 @@ export const myActivitiesResponseSchema = z.object({
  * To server
  * @description 내가 선택한 체험 월별 예약 현황 조회 시 사용하는 쿼리 파라미터의 유효성을 검사하는 스키마
  */
-export const activityReservationParamSchema = z.object({
+export const monthlyScheduleParamSchema = z.object({
   year: z.string().regex(/^\d{4}$/, { message: 'YYYY 형식이어야 합니다.' }),
   month: z.string().regex(/^(0[1-9]|1[0-2])$/, { message: 'MM 형식이어야 합니다.' }),
 });
@@ -34,7 +55,7 @@ export const activityReservationParamSchema = z.object({
  * From server
  * @description 내가 선택한 체험 월별 예약 현황 조회 데이터의 유효성을 검사하는 스키마
  */
-export const activityReservationResponseSchema = z.array(
+export const monthlyScheduleResponseSchema = z.array(
   z.object({
     date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, { message: 'YYYY-MM-DD 형식이어야 합니다.' }),
     reservations: z.object({
@@ -45,7 +66,58 @@ export const activityReservationResponseSchema = z.array(
   }),
 );
 
+/**
+ * To server
+ * @description 내 체험 날짜별 예약 정보(신청, 승인, 거절)가 있는 스케줄 조회 요청 시 사용하는 쿼리 파라미터의 유효성을 검사하는 스키마
+ */
+export const dailyScheduleParamSchema = z.object({
+  date: z.string(),
+});
+
+/**
+ * From server
+ * @description 내 체험 날짜별 예약 정보(신청, 승인, 거절)가 있는 스케줄 데이터의 유효성을 검사하는 스키마
+ */
+export const dailyScheduleResponseSchema = z.array(
+  z.object({
+    scheduleId: z.number().int().positive(),
+    startTime: z.string(),
+    endTime: z.string(),
+    count: z.object({
+      declined: z.number().int().nonnegative(),
+      confirmed: z.number().int().nonnegative(),
+      pending: z.number().int().nonnegative(),
+    }),
+  }),
+);
+
+/**
+ * To server
+ * @description 내 체험 예약 시간대별 예약 내역 조회 요청 시 사용하는 쿼리 파라미터의 유효성을 검사하는 스키마
+ */
+export const timeSlotReservationParamSchema = z.object({
+  cursorId: z.number().int().positive().optional(),
+  size: z.number().int().positive().max(50).default(10).optional(),
+  scheduleId: z.number().int().positive(),
+  status: z.string(),
+});
+
+/**
+ * From server
+ * @description 내 체험 예약 시간대별 예약 내역 데이터의 유효성을 검사하는 스키마
+ */
+export const timeSlotReservationResponseSchema = z.object({
+  reservations: z.array(reservationSchema),
+  totalCount: z.number().int().nonnegative(),
+  cursorId: z.number().int().positive().nullable(),
+});
+
+export type reservation = z.infer<typeof reservationSchema>;
 export type myActivitiesParam = z.infer<typeof myActivitiesParamSchema>;
 export type myActivitiesResponse = z.infer<typeof myActivitiesResponseSchema>;
-export type ActivityReservationParam = z.infer<typeof activityReservationParamSchema>;
-export type ActivityReservationResponse = z.infer<typeof activityReservationResponseSchema>;
+export type monthlyScheduleParam = z.infer<typeof monthlyScheduleParamSchema>;
+export type monthlyScheduleResponse = z.infer<typeof monthlyScheduleResponseSchema>;
+export type dailyScheduleParam = z.infer<typeof dailyScheduleParamSchema>;
+export type dailyScheduleResponse = z.infer<typeof dailyScheduleResponseSchema>;
+export type timeSlotReservationParam = z.infer<typeof timeSlotReservationParamSchema>;
+export type timeSlotReservationResponse = z.infer<typeof timeSlotReservationResponseSchema>;

--- a/packages/design-system/src/components/ReservationInfoCard.tsx
+++ b/packages/design-system/src/components/ReservationInfoCard.tsx
@@ -1,0 +1,49 @@
+import { twMerge } from 'tailwind-merge';
+
+import Button from '@/components/button';
+import UserBadge from '@/components/UserBadge';
+type Status = 'declined' | 'pending' | 'confirmed';
+interface ReservationInfoCardProps {
+  nickname: string;
+  headCount: number;
+  ownerStatus: Status;
+  userStatus: Status;
+  onApprove?: () => void;
+  onReject?: () => void;
+}
+export default function ReservationInfoCard({
+  nickname,
+  headCount,
+  ownerStatus,
+  userStatus,
+  onApprove,
+  onReject,
+}: ReservationInfoCardProps) {
+  const ActionButton = 'h-29 w-68 text-gray-600 hover:outline-2 hover:outline-gray-200';
+  return (
+    <div className='flex w-full items-center justify-between rounded-2xl border border-gray-100 px-16 py-13'>
+      <dl className='flex flex-col gap-4 text-sm'>
+        <dt className='flex gap-8'>
+          <span className='font-bold text-gray-500'>닉네임</span>
+          <span className='font-medium text-gray-950'>{nickname}</span>
+        </dt>
+        <dt className='flex gap-8'>
+          <span className='font-bold text-gray-500'>인원</span>
+          <span className='font-medium text-gray-950'>{headCount}명</span>
+        </dt>
+      </dl>
+      {ownerStatus === 'pending' ? (
+        <div className='flex flex-col gap-8' role='group'>
+          <Button className={twMerge(ActionButton, 'border border-gray-50')} variant='none' onClick={onApprove}>
+            승인하기
+          </Button>
+          <Button className={twMerge(ActionButton, 'bg-gray-50')} variant='none' onClick={onReject}>
+            거절하기
+          </Button>
+        </div>
+      ) : (
+        <UserBadge status={userStatus} />
+      )}
+    </div>
+  );
+}

--- a/packages/design-system/src/components/ReservationInfoCard.tsx
+++ b/packages/design-system/src/components/ReservationInfoCard.tsx
@@ -4,13 +4,41 @@ import Button from '@/components/button';
 import UserBadge from '@/components/UserBadge';
 type Status = 'declined' | 'pending' | 'confirmed';
 interface ReservationInfoCardProps {
+  /**
+   * 예약한 사용자의 닉네임
+   */
   nickname: string;
+  /**
+   * 예약 인원 수
+   */
   headCount: number;
+  /**
+   * 호스트 본인의 예약 처리 상태
+   */
   ownerStatus: Status;
+  /**
+   * 신청자의 예약 상태
+   */
   userStatus: Status;
+  /**
+   * 예약 승인 버튼 클릭 시 실행될 콜백 함수
+   */
   onApprove?: () => void;
+  /**
+   * 예약 거절 버튼 클릭 시 실행될 콜백 함수
+   */
   onReject?: () => void;
 }
+
+/**
+ * 예약 정보 카드 컴포넌트
+ *
+ * 닉네임과 인원 정보를 표시하고, 방장의 상태가 'pending'일 경우
+ * 승인/거절 버튼을 보여주며, 그 외에는 유저 상태 뱃지를 출력합니다.
+ *
+ * @param {ReservationInfoCardProps} props
+ * @returns {JSX.Element}
+ */
 export default function ReservationInfoCard({
   nickname,
   headCount,

--- a/packages/design-system/src/components/index.ts
+++ b/packages/design-system/src/components/index.ts
@@ -15,6 +15,7 @@ export * from './popover';
 export { default as ProfileImageInput } from './ProfileImageInput';
 export { default as RadioGroup } from './RadioGroup/RadioGroup';
 export { default as ReservationCard } from './ReservationCard';
+export { default as ReservationInfoCard } from './ReservationInfoCard';
 export * from './select';
 export { Toaster, useToast } from './Toast';
 export { default as UserBadge } from './UserBadge';

--- a/packages/design-system/src/layouts/Sidebar.tsx
+++ b/packages/design-system/src/layouts/Sidebar.tsx
@@ -35,6 +35,7 @@ export default function DesignSystemLayout() {
             <SidebarNavItem label='MainBanner' to='/docs/MainBanner' />
             <SidebarNavItem label='Carousel' to='/docs/Carousel' />
             <SidebarNavItem label='BottomSheet' to='/docs/BottomSheet' />
+            <SidebarNavItem label='ReservationInfoCard' to='/docs/ReservationInfoCard' />
           </ul>
         </nav>
       </aside>

--- a/packages/design-system/src/pages/ReservationInfoCardDoc.tsx
+++ b/packages/design-system/src/pages/ReservationInfoCardDoc.tsx
@@ -1,0 +1,100 @@
+import ReservationInfoCard from '@/components/ReservationInfoCard';
+import Playground from '@/layouts/Playground';
+
+import DocTemplate, { DocCode } from '../layouts/DocTemplate';
+
+/* Playground는 편집 가능한 코드 블록입니다. */
+/* Playground에서 사용할 예시 코드를 작성해주세요. */
+const code = `<div className='w-400 flex flex-col gap-10'>
+        <ReservationInfoCard onApprove={()=> console.log('hi')} nickname='김지현' headCount={7} ownerStatus='pending' userStatus='pending' />
+      </div>`;
+
+export default function ReservationInfoCardDoc() {
+  return (
+    <>
+      <DocTemplate
+        description={`
+\`ReservationInfoCard\`는 예약 요청 정보를 표시하는 카드 컴포넌트입니다.
+
+- **닉네임**, **인원 수** 등의 기본 정보를 표시하며,
+- 호스트 상태가 \`pending\`일 경우에는 **승인 / 거절 버튼**을 제공하고,
+- 그렇지 않은 경우에는 \`UserBadge\`를 통해 현재 상태를 시각적으로 보여줍니다.
+
+예시:
+\`\`\`tsx
+import { ReservationInfoCard } from '@what-today/design-system';
+
+<ReservationInfoCard
+  nickname="홍길동"
+  headCount={2}
+  ownerStatus="pending"
+  userStatus="confirmed"
+  onApprove={() => handleApprove()}
+  onReject={() => handleReject()}
+/>
+\`\`\`
+`}
+        propsDescription={`
+
+| Prop        | Type                                                   | Required | Description                                   |
+|-------------|--------------------------------------------------------|----------|-----------------------------------------------|
+| nickname    | \`string\`                                              | Yes      | 예약자 닉네임                                  |
+| headCount   | \`number\`                                              | Yes      | 예약 인원 수                                   |
+| ownerStatus | "declined" \\| "pending" \\| "confirmed"          | Yes      | 예약 주최자의 상태                              |
+| userStatus  | "declined" \\| "pending" \\| "confirmed"          | Yes      | 사용자 상태                                     |
+| onApprove   | \`() => void\`                                         | No       | 승인 버튼 클릭 시 호출될 함수                  |
+| onReject    | \`() => void\`                                         | No       | 거절 버튼 클릭 시 호출될 함수                  |
+        
+`}
+        title='ReservationInfoCard'
+      />
+      {/* 실제 컴포넌트를 아래에 작성해주세요 */}
+      {/* 예시 코드 */}
+      <h3 className='mb-8 text-base font-semibold text-gray-600'>기본 상태 (승인/거절)</h3>
+      <div className='w-400'>
+        <ReservationInfoCard
+          headCount={2}
+          nickname='홍길동'
+          ownerStatus='pending'
+          userStatus='pending'
+          onApprove={() => alert('승인됨')}
+          onReject={() => alert('거절됨')}
+        />
+      </div>
+      <DocCode
+        code={`<ReservationInfoCard
+  headCount={2}
+  nickname='홍길동'
+  ownerStatus='pending'
+  userStatus='pending'
+  onApprove={() => alert('승인됨')}
+  onReject={() => alert('거절됨')}
+/>`}
+      />
+      <h3 className='mb-8 text-base font-semibold text-gray-600'>완료 상태 (Badge 표시)</h3>
+      <div className='flex w-400 flex-col gap-10'>
+        <ReservationInfoCard headCount={3} nickname='김철수' ownerStatus='confirmed' userStatus='confirmed' />
+        <ReservationInfoCard headCount={12} nickname='김태일' ownerStatus='confirmed' userStatus='declined' />
+      </div>
+      <DocCode
+        code={`<ReservationInfoCard
+  headCount={3}
+  nickname="김철수"
+  ownerStatus="confirmed"
+  userStatus="confirmed"
+/>
+<ReservationInfoCard 
+  headCount={12} 
+  nickname='김태일' 
+  ownerStatus='confirmed' 
+  userStatus='declined' 
+/>`}
+        language='tsx'
+      />
+      {/* Playground는 편집 가능한 코드 블록입니다. */}
+      <div className='mt-24'>
+        <Playground code={code} scope={{ ReservationInfoCard }} />
+      </div>
+    </>
+  );
+}

--- a/packages/design-system/src/routes/index.tsx
+++ b/packages/design-system/src/routes/index.tsx
@@ -17,7 +17,6 @@ import PopoverDoc from '@pages/PopoverDoc';
 import ProfileImageInputDoc from '@pages/ProfileImageInputDoc';
 import RadioGroupDoc from '@pages/RadioGroupDoc';
 import ReservationCardDoc from '@pages/ReservationCardDoc';
-import SelectDoc from '@pages/SelectDoc';
 import TextareaDoc from '@pages/TextareaDoc';
 import ToastDoc from '@pages/ToastDoc';
 import { createBrowserRouter, Navigate } from 'react-router-dom';
@@ -25,6 +24,7 @@ import { createBrowserRouter, Navigate } from 'react-router-dom';
 import FooterDoc from '@/pages/FooterDoc';
 import MainCardDoc from '@/pages/MainCardDoc';
 import OwnerBadgeDoc from '@/pages/OwnerBadgeDoc';
+import ReservationInfoCardDoc from '@/pages/ReservationInfoCardDoc';
 import UserBadgeDoc from '@/pages/UserBadgeDoc';
 
 const router = createBrowserRouter([
@@ -93,8 +93,12 @@ const router = createBrowserRouter([
         element: <PopoverDoc />,
       },
       {
-        path: 'Select',
-        element: <SelectDoc />,
+        path: 'Popover',
+        element: <PopoverDoc />,
+      },
+      {
+        path: 'ReservationInfoCard',
+        element: <ReservationInfoCardDoc />,
       },
       {
         path: 'Input',


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- 이슈 번호 #113 

## 📌 작업 내용
<!-- 해당 PR의 변경 사항을 자세하게 적어주세요.-->
- 예약 정보 컴포넌트 UI 구현
- 예약 정보 관련 일부 스키마 정의, api 연결 (mpck data로 할려다보니 더 헷갈려서 일부는 api 연결)

## ✅ 체크리스트

- [x] PR 하기 전에 이슈에서 빼먹은건 없는지 확인했습니다
  - [x] 라벨 및 마일스톤을 사이드 탭에서 등록했습니다.
- [x] PR을 보내는 브랜치가 올바른지 확인했습니다.
- [x] 팀원들이 리뷰하기 쉽도록 설명을 자세하게 작성했습니다.
- [x] 변경사항을 충분히 테스트 했습니다.
- [x] (함수를 구현 했을 때) JSDoc을 양식에 맞춰서 작성했습니다.
- [x] 컨벤션에 맞게 구현했습니다.

## 📷 UI 변경 사항 (선택)
<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->

https://github.com/user-attachments/assets/b671d3f8-25ca-4a01-ad9f-1d7e1852a332


## ❓무슨 문제가 발생했나요? (선택)
- 특정 트리거가 있는게 아니라 날짜 선택할 때마다 그 위치를 상대로 popover가 열려야 하는데 잘 안되네요... 우선 내부 contents UI랑 bottomSheet 적용까지는 했는데 PC일 때 popover는 도움이 필요합니다..ㅎㅎ

## 💬 기타 참고 사항 (선택)
<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->
- 현재 월 예약 현황, 날짜별 예약 현황 까지는 api 연결되었습니다. 시간대별 예약 현황은 추가 기능 구현할 예정입니다!
