### PR TITLE
마이페이지 사이드바 리팩토링

### DIFF
--- a/apps/what-today/src/components/MypageSidebar.tsx
+++ b/apps/what-today/src/components/MypageSidebar.tsx
@@ -66,7 +66,7 @@ export default function MypageSidebar({ profileImgUrl, onLogoutClick, onClick, i
         // 공통 스타일
         'fixed z-50 max-w-200 min-w-200 rounded-xl border border-gray-50 bg-white shadow-[0px_4px_24px_rgba(156,180,202,0.2)] transition duration-300 md:static md:h-fit xl:w-280',
         // 모바일에서 Drawer 위치
-        isOpen ? 'h-474 translate-x-0' : 'bg-primary-100 border-primary-100 h-50 -translate-x-full',
+        isOpen ? 'h-474 translate-x-0' : 'h-50 -translate-x-full border-gray-200 bg-gray-200',
         'md:translate-x-0',
         'md:border-gray-50 md:bg-white',
       )}

--- a/apps/what-today/src/layouts/Mypage.tsx
+++ b/apps/what-today/src/layouts/Mypage.tsx
@@ -1,6 +1,7 @@
 import { Button, ChevronIcon, useToast } from '@what-today/design-system';
 import { useEffect, useState } from 'react';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
+import { twMerge } from 'tailwind-merge';
 
 import MypageSidebar from '@/components/MypageSidebar';
 import useAuth from '@/hooks/useAuth';
@@ -40,11 +41,16 @@ export default function MyPageLayout() {
         onClick={() => setSidebarOpen((prev) => !prev)}
         onLogoutClick={handleLogout}
       />
+      <Button
+        className={twMerge('fixed top-68 left-4 z-60 w-fit p-0 md:hidden', isSidebarOpen && 'hidden')}
+        size='xs'
+        variant='none'
+        onClick={() => setSidebarOpen(true)}
+      >
+        <ChevronIcon className='h-16' color='var(--color-gray-600)' direction='right' />
+      </Button>
       {/* Outlet으로 상세 화면 표시 */}
       <div className='flex-1 p-4'>
-        <Button className='w-fit p-0 md:hidden' size='xs' variant='none' onClick={() => setSidebarOpen(true)}>
-          <ChevronIcon className='h-16' direction='left' />
-        </Button>
         <Outlet />
       </div>
     </div>

--- a/apps/what-today/src/pages/mypage/edit-profile/index.tsx
+++ b/apps/what-today/src/pages/mypage/edit-profile/index.tsx
@@ -130,14 +130,14 @@ export default function EditProfilePage() {
 
   return (
     <div className='flex flex-col gap-12 text-gray-900'>
-      <div className='flex items-center gap-4'>
+      <div className='flex items-center gap-4 border-b border-b-gray-50 pb-20'>
         <Button className='h-fit w-fit' variant='none' onClick={handleNavigateToMypage}>
           <ChevronIcon color='var(--color-gray-300)' direction='left' />
         </Button>
         <h1 className='text-xl font-bold'>내 정보</h1>
       </div>
       <form
-        className='flex w-full flex-col items-center justify-center gap-32'
+        className='flex w-full flex-col items-center justify-center gap-32 pt-20'
         onReset={handleReset}
         onSubmit={handleSubmit}
       >

--- a/apps/what-today/src/pages/mypage/manage-activities/index.tsx
+++ b/apps/what-today/src/pages/mypage/manage-activities/index.tsx
@@ -65,7 +65,7 @@ export default function ManageActivitiesPage() {
           </Button>
           <h1 className='text-xl font-bold text-gray-950'>내 체험 관리</h1>
         </div>
-        <div className='md:items-between flex flex-col justify-between gap-10 pt-10 md:flex-row'>
+        <div className='flex flex-col justify-between gap-10 pt-10 md:flex-row'>
           <p className='text-md font-medium text-gray-500'>체험을 등록하거나 수정 및 삭제가 가능합니다.</p>
           <Button className='w-full md:w-138' onClick={() => navigate('/')}>
             체험 등록하기

--- a/apps/what-today/src/pages/mypage/manage-activities/index.tsx
+++ b/apps/what-today/src/pages/mypage/manage-activities/index.tsx
@@ -1,4 +1,4 @@
-import { Button, ExperienceCard, NoResult } from '@what-today/design-system';
+import { Button, ChevronIcon, ExperienceCard, NoResult } from '@what-today/design-system';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
@@ -9,6 +9,10 @@ export default function ManageActivitiesPage() {
   const navigate = useNavigate();
   const [data, setData] = useState<myActivitiesResponse | null>(null);
   const [loading, setLoading] = useState(true);
+
+  const handleNavigateToMypage = () => {
+    navigate('/mypage');
+  };
 
   const fetchMyActivities = async () => {
     try {
@@ -54,15 +58,19 @@ export default function ManageActivitiesPage() {
 
   return (
     <div className='flex flex-col gap-13 md:gap-30'>
-      <header className='flex flex-col justify-between gap-14 py-1 md:flex-row md:items-center'>
-        <div className='flex flex-col gap-10'>
+      <header className='flex flex-col gap-10'>
+        <div className='flex items-center gap-4 border-b border-b-gray-50 pb-20'>
+          <Button className='h-fit w-fit' variant='none' onClick={handleNavigateToMypage}>
+            <ChevronIcon color='var(--color-gray-300)' direction='left' />
+          </Button>
           <h1 className='text-xl font-bold text-gray-950'>내 체험 관리</h1>
-          <p className='text-md font-medium text-gray-500'>체험을 등록하거나 수정 및 삭제가 가능합니다.</p>
         </div>
-        {/* 추후 체험등록 페이지로 수정 예정 */}
-        <Button className='w-full md:w-138' onClick={() => navigate('/')}>
-          체험 등록하기
-        </Button>
+        <div className='md:items-between flex flex-col justify-between gap-10 pt-10 md:flex-row'>
+          <p className='text-md font-medium text-gray-500'>체험을 등록하거나 수정 및 삭제가 가능합니다.</p>
+          <Button className='w-full md:w-138' onClick={() => navigate('/')}>
+            체험 등록하기
+          </Button>
+        </div>
       </header>
       <section aria-label='체험 카드 목록' className='flex flex-col gap-30 xl:gap-24'>
         {content}

--- a/apps/what-today/src/pages/mypage/reservations-status/index.tsx
+++ b/apps/what-today/src/pages/mypage/reservations-status/index.tsx
@@ -1,12 +1,14 @@
-import { NoResult, type ReservationStatus, Select } from '@what-today/design-system';
+import { Button, ChevronIcon, NoResult, type ReservationStatus, Select } from '@what-today/design-system';
 import dayjs from 'dayjs';
 import { type ReactNode, type SetStateAction, useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import { getMonthlyReservations, getMyActivities } from '@/apis/myActivities';
 import ReservationCalendar from '@/components/reservations-status/ReservationCalendar';
 import type { ActivityReservationResponse, myActivitiesResponse } from '@/schemas/myActivities';
 
 export default function ReservationsStatusPage() {
+  const navigate = useNavigate();
   const [activitiesData, setActivitiesData] = useState<myActivitiesResponse | null>(null);
   const [reservation, setReservation] = useState<ActivityReservationResponse>([]);
   const [activitiesLoading, setActivitiesLoading] = useState(true);
@@ -22,6 +24,9 @@ export default function ReservationsStatusPage() {
 
   const handleValueChange = (value: SetStateAction<{ value: string; label: ReactNode } | null>) => {
     setSelectedActivity(value);
+  };
+  const handleNavigateToMypage = () => {
+    navigate('/mypage');
   };
 
   const handleDateChange = (date: string) => {
@@ -119,8 +124,13 @@ export default function ReservationsStatusPage() {
   return (
     <div className='flex flex-col md:gap-24 xl:gap-30'>
       <header className='mb-18 flex flex-col gap-10 p-1 md:mb-0'>
-        <h1 className='text-xl font-bold text-gray-950'>예약 현황</h1>
-        <p className='text-md font-medium text-gray-500'>내 체험에 예약된 내역들을 한 눈에 확인할 수 있습니다.</p>
+        <div className='flex items-center gap-4 border-b border-b-gray-50 pb-20'>
+          <Button className='h-fit w-fit' variant='none' onClick={handleNavigateToMypage}>
+            <ChevronIcon color='var(--color-gray-300)' direction='left' />
+          </Button>
+          <h1 className='text-xl font-bold text-gray-950'>예약 현황</h1>
+        </div>
+        <p className='text-md pt-10 font-medium text-gray-500'>내 체험에 예약된 내역들을 한 눈에 확인할 수 있습니다.</p>
       </header>
       {content}
     </div>

--- a/packages/design-system/src/routes/index.tsx
+++ b/packages/design-system/src/routes/index.tsx
@@ -11,8 +11,8 @@ import IconDoc from '@pages/IconDoc';
 import InputDoc from '@pages/InputDoc';
 import LandingPage from '@pages/LandingPage';
 import LogoDoc from '@pages/LogoDoc';
-import MainCardDoc from '@pages/MainCardDoc';
 import MainBannerDoc from '@pages/MainBannerDoc';
+import MainCardDoc from '@pages/MainCardDoc';
 import MainSearchInputDoc from '@pages/MainSearchInputDoc';
 import ModalDoc from '@pages/ModalDoc';
 import NoResultDoc from '@pages/NoResultDoc';
@@ -28,8 +28,8 @@ import TextareaDoc from '@pages/TextareaDoc';
 import TimePickerDoc from '@pages/TimePickerDoc';
 import ToastDoc from '@pages/ToastDoc';
 import { createBrowserRouter, Navigate } from 'react-router-dom';
+
 import FooterDoc from '@/pages/FooterDoc';
-import MainCardDoc from '@/pages/MainCardDoc';
 import OwnerBadgeDoc from '@/pages/OwnerBadgeDoc';
 import UserBadgeDoc from '@/pages/UserBadgeDoc';
 
@@ -131,7 +131,6 @@ const router = createBrowserRouter([
         element: <CalendarDoc />,
       },
       {
-
         path: 'ExperienceImageUpload',
         element: <ExperienceImageUploadDoc />,
       },


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- 이슈 번호 #135

## 📌 작업 내용
<!-- 해당 PR의 변경 사항을 자세하게 적어주세요.-->
- pip 버튼 모양 수정
- 각 페이지에 뒤로가기 버튼 추가

## ✅ 체크리스트

- [x] PR 하기 전에 이슈에서 빼먹은건 없는지 확인했습니다
  - [x] 라벨 및 마일스톤을 사이드 탭에서 등록했습니다.
- [x] PR을 보내는 브랜치가 올바른지 확인했습니다.
- [x] 팀원들이 리뷰하기 쉽도록 설명을 자세하게 작성했습니다.
- [x] 변경사항을 충분히 테스트 했습니다.
- [x] (함수를 구현 했을 때) JSDoc을 양식에 맞춰서 작성했습니다.
- [x] 컨벤션에 맞게 구현했습니다.

## 📷 UI 변경 사항 (선택)
<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->

https://github.com/user-attachments/assets/4cee8d83-3083-4a14-a8bf-91dec292d0ab


## ❓무슨 문제가 발생했나요? (선택)
-

## 💬 기타 참고 사항 (선택)
<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->
- 마이페이지 현재 머지된 3개는 UI 통일 하였습니다. (뒤로가기, 제목과 구분선)
- 예약 내역 페이지만 나중에 추가하면 될 것 같아요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * 모바일에서 마이페이지 사이드바가 닫힌 상태의 배경색과 테두리색이 변경되었습니다.
  * 프로필 수정 및 활동 관리, 예약 현황 페이지의 헤더와 폼, 버튼 등에 여백과 구분선이 추가되어 레이아웃이 개선되었습니다.

* **New Features**
  * 마이페이지 관련 페이지에서 뒤로 가기 버튼이 추가되어, 상위 페이지로 쉽게 이동할 수 있습니다.
  * 모바일에서 사이드바 열기 버튼의 위치와 스타일이 변경되어 접근성이 향상되었습니다.

* **Refactor**
  * 일부 레이아웃 구조가 재정비되어 UI가 더 명확하게 구분됩니다.

* **Chores**
  * 내부 코드의 import 순서와 공백이 정리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->