### PR TITLE
내 알림 API 연결

### DIFF
--- a/apps/what-today/src/apis/myNotifications.ts
+++ b/apps/what-today/src/apis/myNotifications.ts
@@ -2,6 +2,15 @@ import { type NotificationsResponse, notificationsResponseSchema } from '@/schem
 
 import axiosInstance from './axiosInstance';
 
+/**
+ * @function getMyNotifications
+ * @description 내 알림 목록을 불러오는 API 요청 함수
+ *
+ * @param {number | null} [cursorId] - 마지막으로 불러온 알림 ID. 이후 알림을 가져오기 위한 기준 값 (기본값: null)
+ * @param {number} [size=10] - 한 페이지에 불러올 알림 개수 (기본값: 10)
+ *
+ * @returns {Promise<NotificationsResponse>} Zod 파싱을 통과한 알림 응답 객체
+ */
 export const getMyNotifications = async ({
   cursorId,
   size = 10,
@@ -18,6 +27,15 @@ export const getMyNotifications = async ({
   return notificationsResponseSchema.parse(response.data);
 };
 
+/**
+ * @function deleteMyNotifications
+ * @description 특정 알림을 삭제하는 DELETE API 요청 함수
+ * - 응답 본문이 없거나 단순 에러 메시지(string)이므로, zod 검사 없이 Axios 응답 객체를 그대로 반환합니다.
+ *
+ * @param {number} notificationId - 삭제할 알림의 고유 ID
+ *
+ * @returns {Promise<AxiosResponse>} 삭제 요청에 대한 Axios 응답 객체
+ */
 export const deleteMyNotifications = async (notificationId: number) => {
   const response = axiosInstance.delete(`/my-notifications/${notificationId}`);
   return response;

--- a/apps/what-today/src/apis/myNotifications.ts
+++ b/apps/what-today/src/apis/myNotifications.ts
@@ -1,21 +1,6 @@
-import mockData from '@/components/notification/mock-notifications-pages.json';
 import { type NotificationsResponse, notificationsResponseSchema } from '@/schemas/myNotifications';
 
-// export const getMyNotifications = async ({
-//   cursorId,
-//   size = 10,
-// }: {
-//   cursorId?: number | null;
-//   size?: number;
-// }): Promise<NotificationsResponse> => {
-//   const response = await axiosInstance.get('/my-notifications', {
-//     params: {
-//       cursorId,
-//       size,
-//     },
-//   });
-//   return notificationsResponseSchema.parse(response.data);
-// };
+import axiosInstance from './axiosInstance';
 
 export const getMyNotifications = async ({
   cursorId,
@@ -24,24 +9,16 @@ export const getMyNotifications = async ({
   cursorId?: number | null;
   size?: number;
 }): Promise<NotificationsResponse> => {
-  const mockPages = mockData as NotificationsResponse[];
+  const response = await axiosInstance.get('/my-notifications', {
+    params: {
+      cursorId,
+      size,
+    },
+  });
+  return notificationsResponseSchema.parse(response.data);
+};
 
-  // 1. 초기 요청이면 첫 페이지 반환
-  if (cursorId === null || cursorId === undefined) {
-    return notificationsResponseSchema.parse(mockPages[0]);
-  }
-
-  // 2. cursorId 기반으로 다음 페이지 찾기
-  const page = mockPages.find((p) => p.notifications[0]?.id === cursorId + 1);
-
-  // 3. 못 찾으면 빈 페이지 반환
-  if (!page) {
-    return {
-      cursorId: null,
-      totalCount: mockPages[0].totalCount, // 첫 페이지 기준 totalCount 사용
-      notifications: [],
-    };
-  }
-
-  return notificationsResponseSchema.parse(page);
+export const deleteMyNotifications = async (notificationId: number) => {
+  const response = axiosInstance.delete(`/my-notifications/${notificationId}`);
+  return response;
 };

--- a/apps/what-today/src/apis/myNotifications.ts
+++ b/apps/what-today/src/apis/myNotifications.ts
@@ -1,0 +1,47 @@
+import mockData from '@/components/notification/mock-notifications-pages.json';
+import { type NotificationsResponse, notificationsResponseSchema } from '@/schemas/myNotifications';
+
+// export const getMyNotifications = async ({
+//   cursorId,
+//   size = 10,
+// }: {
+//   cursorId?: number | null;
+//   size?: number;
+// }): Promise<NotificationsResponse> => {
+//   const response = await axiosInstance.get('/my-notifications', {
+//     params: {
+//       cursorId,
+//       size,
+//     },
+//   });
+//   return notificationsResponseSchema.parse(response.data);
+// };
+
+export const getMyNotifications = async ({
+  cursorId,
+  size = 10,
+}: {
+  cursorId?: number | null;
+  size?: number;
+}): Promise<NotificationsResponse> => {
+  const mockPages = mockData as NotificationsResponse[];
+
+  // 1. 초기 요청이면 첫 페이지 반환
+  if (cursorId === null || cursorId === undefined) {
+    return notificationsResponseSchema.parse(mockPages[0]);
+  }
+
+  // 2. cursorId 기반으로 다음 페이지 찾기
+  const page = mockPages.find((p) => p.notifications[0]?.id === cursorId + 1);
+
+  // 3. 못 찾으면 빈 페이지 반환
+  if (!page) {
+    return {
+      cursorId: null,
+      totalCount: mockPages[0].totalCount, // 첫 페이지 기준 totalCount 사용
+      notifications: [],
+    };
+  }
+
+  return notificationsResponseSchema.parse(page);
+};

--- a/apps/what-today/src/apis/myNotifications.ts
+++ b/apps/what-today/src/apis/myNotifications.ts
@@ -37,6 +37,6 @@ export const getMyNotifications = async ({
  * @returns {Promise<AxiosResponse>} 삭제 요청에 대한 Axios 응답 객체
  */
 export const deleteMyNotifications = async (notificationId: number) => {
-  const response = axiosInstance.delete(`/my-notifications/${notificationId}`);
+  const response = await axiosInstance.delete(`/my-notifications/${notificationId}`);
   return response;
 };

--- a/apps/what-today/src/components/Header.tsx
+++ b/apps/what-today/src/components/Header.tsx
@@ -30,7 +30,7 @@ export default function Header() {
             {user?.profileImageUrl ? (
               <img
                 alt='프로필 이미지'
-                className='size-24 rounded-full border border-gray-50 object-cover'
+                className='size-24 rounded-full border border-gray-50 bg-white object-cover'
                 src={user.profileImageUrl}
               />
             ) : (

--- a/apps/what-today/src/components/notification/NotificationPopover.tsx
+++ b/apps/what-today/src/components/notification/NotificationPopover.tsx
@@ -128,7 +128,7 @@ export default function NotificationPopover({ isMobile }: NotificationPopoverPro
         </Button>
       </Popover.Trigger>
       <Popover.Content className='mt-8 rounded-2xl border border-gray-100 bg-white p-10 shadow-sm'>
-        <h1 className='my-8 ml-auto px-16 font-bold text-gray-950'>알림 {data?.pages[0].totalCount ?? 0}개</h1>
+        <h1 className='my-8 ml-auto px-16 font-bold text-gray-950'>알림 {data?.pages[0].totalCount}개</h1>
 
         <div ref={scrollContainerRef} className='relative max-h-400 w-300 overflow-y-scroll'>
           {isLoading && <p className='text-md my-70 text-center text-gray-400'>Loading...</p>}

--- a/apps/what-today/src/components/notification/NotificationPopover.tsx
+++ b/apps/what-today/src/components/notification/NotificationPopover.tsx
@@ -20,6 +20,15 @@ export default function NotificationPopover({ isMobile }: NotificationPopoverPro
   const queryClient = useQueryClient();
   const { toast } = useToast();
 
+  /**
+   * @function fetchNotifications
+   * @description 무한 스크롤을 위한 알림 데이터를 요청합니다.
+   * - `cursorId`를 기반으로 다음 페이지의 알림 목록을 받아오며,
+   * - 빈 배열이나 cursorId가 null이면 더 이상 불러올 페이지가 없다고 판단합니다.
+   *
+   * @param {number | null} cursorId - 마지막으로 불러온 알림 ID (페이지네이션 기준값)
+   * @returns {Promise<NotificationsResponse>} 알림 목록, 커서 ID, 전체 알림 개수를 포함한 응답 객체
+   */
   const fetchNotifications = async ({ cursorId }: { cursorId: number | null }): Promise<NotificationsResponse> => {
     const params = {
       size: 10,
@@ -35,6 +44,17 @@ export default function NotificationPopover({ isMobile }: NotificationPopoverPro
     };
   };
 
+  /**
+   * @description 무한 스크롤 기반으로 알림 목록을 불러오는 React Query 훅입니다.
+   *
+   * @returns {
+   *   data: 알림 페이지 데이터 목록
+   *   fetchNextPage: 다음 페이지를 불러오는 함수
+   *   hasNextPage: 다음 페이지 유무
+   *   isFetchingNextPage: 다음 페이지 불러오는 중 여부
+   *   isLoading: 초기 로딩 여부
+   * }
+   */
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } = useInfiniteQuery<
     NotificationsResponse,
     Error
@@ -54,6 +74,12 @@ export default function NotificationPopover({ isMobile }: NotificationPopoverPro
     staleTime: 30 * 1000,
   });
 
+  /**
+   * @description 내 알림을 삭제하는 mutation 함수입니다.
+   *
+   * @onSuccess 삭제 성공 시 알림 목록 쿼리 무효화 및 성공 토스트 출력
+   * @onError 삭제 실패 시 에러 메시지를 파싱하여 에러 토스트 출력
+   */
   const deleteNotification = useMutation({
     mutationFn: deleteMyNotifications,
     onError: (error: AxiosError<{ message: string }>) => {
@@ -124,7 +150,7 @@ export default function NotificationPopover({ isMobile }: NotificationPopoverPro
           {!isLoading && data?.pages.every((page) => page.notifications.length === 0) && (
             <p className='text-md my-70 text-center text-gray-400'>알림이 없습니다.</p>
           )}
-          <div ref={observerRef} className='h-6 w-full' />
+          <div ref={observerRef} className='h-6 w-full' /> {/* 무한 스크롤 감지용 */}
         </div>
       </Popover.Content>
     </Popover.Root>

--- a/apps/what-today/src/components/notification/mock-notifications-pages.json
+++ b/apps/what-today/src/components/notification/mock-notifications-pages.json
@@ -1,0 +1,290 @@
+[
+  {
+    "cursorId": 10,
+    "totalCount": 30,
+    "notifications": [
+      {
+        "id": 1,
+        "teamId": "1-team",
+        "userId": 2001,
+        "content": "더미 알림 내용 1번입니다.",
+        "createdAt": "2025-07-26T07:23:08.902264Z",
+        "updatedAt": "2025-07-26T07:23:08.902264Z",
+        "deletedAt": null
+      },
+      {
+        "id": 2,
+        "teamId": "2-team",
+        "userId": 2002,
+        "content": "더미 알림 내용 2번입니다.",
+        "createdAt": "2025-07-26T07:22:08.902264Z",
+        "updatedAt": "2025-07-26T07:22:08.902264Z",
+        "deletedAt": null
+      },
+      {
+        "id": 3,
+        "teamId": "3-team",
+        "userId": 2003,
+        "content": "더미 알림 내용 3번입니다.",
+        "createdAt": "2025-07-26T07:21:08.902264Z",
+        "updatedAt": "2025-07-26T07:21:08.902264Z",
+        "deletedAt": null
+      },
+      {
+        "id": 4,
+        "teamId": "4-team",
+        "userId": 2004,
+        "content": "더미 알림 내용 4번입니다.",
+        "createdAt": "2025-07-26T07:20:08.902264Z",
+        "updatedAt": "2025-07-26T07:20:08.902264Z",
+        "deletedAt": null
+      },
+      {
+        "id": 5,
+        "teamId": "5-team",
+        "userId": 2005,
+        "content": "더미 알림 내용 5번입니다.",
+        "createdAt": "2025-07-26T07:19:08.902264Z",
+        "updatedAt": "2025-07-26T07:19:08.902264Z",
+        "deletedAt": null
+      },
+      {
+        "id": 6,
+        "teamId": "6-team",
+        "userId": 2006,
+        "content": "더미 알림 내용 6번입니다.",
+        "createdAt": "2025-07-26T07:18:08.902264Z",
+        "updatedAt": "2025-07-26T07:18:08.902264Z",
+        "deletedAt": null
+      },
+      {
+        "id": 7,
+        "teamId": "7-team",
+        "userId": 2007,
+        "content": "더미 알림 내용 7번입니다.",
+        "createdAt": "2025-07-26T07:17:08.902264Z",
+        "updatedAt": "2025-07-26T07:17:08.902264Z",
+        "deletedAt": null
+      },
+      {
+        "id": 8,
+        "teamId": "8-team",
+        "userId": 2008,
+        "content": "더미 알림 내용 8번입니다.",
+        "createdAt": "2025-07-26T07:16:08.902264Z",
+        "updatedAt": "2025-07-26T07:16:08.902264Z",
+        "deletedAt": null
+      },
+      {
+        "id": 9,
+        "teamId": "9-team",
+        "userId": 2009,
+        "content": "더미 알림 내용 9번입니다.",
+        "createdAt": "2025-07-26T07:15:08.902264Z",
+        "updatedAt": "2025-07-26T07:15:08.902264Z",
+        "deletedAt": null
+      },
+      {
+        "id": 10,
+        "teamId": "10-team",
+        "userId": 2010,
+        "content": "더미 알림 내용 10번입니다.",
+        "createdAt": "2025-07-26T07:14:08.902264Z",
+        "updatedAt": "2025-07-26T07:14:08.902264Z",
+        "deletedAt": null
+      }
+    ]
+  },
+  {
+    "cursorId": 20,
+    "totalCount": 30,
+    "notifications": [
+      {
+        "id": 11,
+        "teamId": "11-team",
+        "userId": 2011,
+        "content": "더미 알림 내용 11번입니다.",
+        "createdAt": "2025-07-26T07:13:08.902313Z",
+        "updatedAt": "2025-07-26T07:13:08.902313Z",
+        "deletedAt": null
+      },
+      {
+        "id": 12,
+        "teamId": "12-team",
+        "userId": 2012,
+        "content": "더미 알림 내용 12번입니다.",
+        "createdAt": "2025-07-26T07:12:08.902313Z",
+        "updatedAt": "2025-07-26T07:12:08.902313Z",
+        "deletedAt": null
+      },
+      {
+        "id": 13,
+        "teamId": "13-team",
+        "userId": 2013,
+        "content": "더미 알림 내용 13번입니다.",
+        "createdAt": "2025-07-26T07:11:08.902313Z",
+        "updatedAt": "2025-07-26T07:11:08.902313Z",
+        "deletedAt": null
+      },
+      {
+        "id": 14,
+        "teamId": "14-team",
+        "userId": 2014,
+        "content": "더미 알림 내용 14번입니다.",
+        "createdAt": "2025-07-26T07:10:08.902313Z",
+        "updatedAt": "2025-07-26T07:10:08.902313Z",
+        "deletedAt": null
+      },
+      {
+        "id": 15,
+        "teamId": "15-team",
+        "userId": 2015,
+        "content": "더미 알림 내용 15번입니다.",
+        "createdAt": "2025-07-26T07:09:08.902313Z",
+        "updatedAt": "2025-07-26T07:09:08.902313Z",
+        "deletedAt": null
+      },
+      {
+        "id": 16,
+        "teamId": "16-team",
+        "userId": 2016,
+        "content": "더미 알림 내용 16번입니다.",
+        "createdAt": "2025-07-26T07:08:08.902313Z",
+        "updatedAt": "2025-07-26T07:08:08.902313Z",
+        "deletedAt": null
+      },
+      {
+        "id": 17,
+        "teamId": "17-team",
+        "userId": 2017,
+        "content": "더미 알림 내용 17번입니다.",
+        "createdAt": "2025-07-26T07:07:08.902313Z",
+        "updatedAt": "2025-07-26T07:07:08.902313Z",
+        "deletedAt": null
+      },
+      {
+        "id": 18,
+        "teamId": "18-team",
+        "userId": 2018,
+        "content": "더미 알림 내용 18번입니다.",
+        "createdAt": "2025-07-26T07:06:08.902313Z",
+        "updatedAt": "2025-07-26T07:06:08.902313Z",
+        "deletedAt": null
+      },
+      {
+        "id": 19,
+        "teamId": "19-team",
+        "userId": 2019,
+        "content": "더미 알림 내용 19번입니다.",
+        "createdAt": "2025-07-26T07:05:08.902313Z",
+        "updatedAt": "2025-07-26T07:05:08.902313Z",
+        "deletedAt": null
+      },
+      {
+        "id": 20,
+        "teamId": "20-team",
+        "userId": 2020,
+        "content": "더미 알림 내용 20번입니다.",
+        "createdAt": "2025-07-26T07:04:08.902313Z",
+        "updatedAt": "2025-07-26T07:04:08.902313Z",
+        "deletedAt": null
+      }
+    ]
+  },
+  {
+    "cursorId": null,
+    "totalCount": 30,
+    "notifications": [
+      {
+        "id": 21,
+        "teamId": "21-team",
+        "userId": 2021,
+        "content": "더미 알림 내용 21번입니다.",
+        "createdAt": "2025-07-26T07:03:08.902348Z",
+        "updatedAt": "2025-07-26T07:03:08.902348Z",
+        "deletedAt": null
+      },
+      {
+        "id": 22,
+        "teamId": "22-team",
+        "userId": 2022,
+        "content": "더미 알림 내용 22번입니다.",
+        "createdAt": "2025-07-26T07:02:08.902348Z",
+        "updatedAt": "2025-07-26T07:02:08.902348Z",
+        "deletedAt": null
+      },
+      {
+        "id": 23,
+        "teamId": "23-team",
+        "userId": 2023,
+        "content": "더미 알림 내용 23번입니다.",
+        "createdAt": "2025-07-26T07:01:08.902348Z",
+        "updatedAt": "2025-07-26T07:01:08.902348Z",
+        "deletedAt": null
+      },
+      {
+        "id": 24,
+        "teamId": "24-team",
+        "userId": 2024,
+        "content": "더미 알림 내용 24번입니다.",
+        "createdAt": "2025-07-26T07:00:08.902348Z",
+        "updatedAt": "2025-07-26T07:00:08.902348Z",
+        "deletedAt": null
+      },
+      {
+        "id": 25,
+        "teamId": "25-team",
+        "userId": 2025,
+        "content": "더미 알림 내용 25번입니다.",
+        "createdAt": "2025-07-26T06:59:08.902348Z",
+        "updatedAt": "2025-07-26T06:59:08.902348Z",
+        "deletedAt": null
+      },
+      {
+        "id": 26,
+        "teamId": "26-team",
+        "userId": 2026,
+        "content": "더미 알림 내용 26번입니다.",
+        "createdAt": "2025-07-26T06:58:08.902348Z",
+        "updatedAt": "2025-07-26T06:58:08.902348Z",
+        "deletedAt": null
+      },
+      {
+        "id": 27,
+        "teamId": "27-team",
+        "userId": 2027,
+        "content": "더미 알림 내용 27번입니다.",
+        "createdAt": "2025-07-26T06:57:08.902348Z",
+        "updatedAt": "2025-07-26T06:57:08.902348Z",
+        "deletedAt": null
+      },
+      {
+        "id": 28,
+        "teamId": "28-team",
+        "userId": 2028,
+        "content": "더미 알림 내용 28번입니다.",
+        "createdAt": "2025-07-26T06:56:08.902348Z",
+        "updatedAt": "2025-07-26T06:56:08.902348Z",
+        "deletedAt": null
+      },
+      {
+        "id": 29,
+        "teamId": "29-team",
+        "userId": 2029,
+        "content": "더미 알림 내용 29번입니다.",
+        "createdAt": "2025-07-26T06:55:08.902348Z",
+        "updatedAt": "2025-07-26T06:55:08.902348Z",
+        "deletedAt": null
+      },
+      {
+        "id": 30,
+        "teamId": "30-team",
+        "userId": 2030,
+        "content": "더미 알림 내용 30번입니다.",
+        "createdAt": "2025-07-26T06:54:08.902348Z",
+        "updatedAt": "2025-07-26T06:54:08.902348Z",
+        "deletedAt": null
+      }
+    ]
+  }
+]

--- a/apps/what-today/src/hooks/useIntersectionObserver.ts
+++ b/apps/what-today/src/hooks/useIntersectionObserver.ts
@@ -1,0 +1,65 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * @description 무한 스크롤을 위한 Intersection Observer 커스텀 훅
+ *
+ * @param {() => void} callback - 타겟 요소가 화면에 들어왔을 때 실행할 함수
+ * @param {boolean} isLoading - 데이터를 로딩 중인지 여부 (true일 경우 observe하지 않음)
+ * @param {boolean} isLastPage - 더 이상 로드할 페이지가 없는지 여부 (true일 경우 observe하지 않음)
+ * @param {Element | null} [root] - IntersectionObserver의 root 요소 (기본값: null → 뷰포트 기준)
+ * @param {unknown} [watch] - 관찰 재등록을 위한 외부 상태 (예: Popover open 상태 등)
+ *
+ *
+ * @example
+ * ```tsx
+ * const scrollContainerRef = useRef(null);
+ * const observerRef = useIntersectionObserver(
+ *   () => fetchNextPage(),
+ *   isLoading,
+ *   isLastPage,
+ *   scrollContainerRef.current,
+ *   open,
+ * );
+ *
+ * return <div ref={observerRef} />;
+ * ```
+ */
+export default function useIntersectionObserver(
+  callback: () => void,
+  isLoading: boolean,
+  isLastPage: boolean,
+  root?: Element | null,
+  watch?: unknown,
+) {
+  const observerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      const target = observerRef.current;
+      if (!target) return;
+      if (isLoading || isLastPage) return;
+
+      const observer = new IntersectionObserver(
+        (entries) => {
+          if (entries[0].isIntersecting) {
+            callback();
+          }
+        },
+        {
+          threshold: 0.1,
+          root: root ?? null,
+        },
+      );
+
+      observer.observe(target);
+
+      return () => {
+        observer.disconnect();
+      };
+    }, 10); // Portal이 DOM에 렌더 후 등록되도록 지연 (Portal이 아닌 상황에서도 0.01초로 영향이 크지 않음)
+
+    return () => clearTimeout(timeout);
+  }, [callback, isLoading, isLastPage, root, watch]);
+
+  return observerRef;
+}

--- a/apps/what-today/src/schemas/myNotifications.ts
+++ b/apps/what-today/src/schemas/myNotifications.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+
+/**
+ * From server
+ * @description 알림 스키마
+ */
+export const notificationSchema = z.object({
+  id: z.number(),
+  teamId: z.string(),
+  userId: z.number(),
+  content: z.string(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+  deletedAt: z.string().datetime().nullable(),
+});
+
+/**
+ * From server
+ * @description 내 알림 목록 응답 스키마
+ */
+export const notificationsResponseSchema = z.object({
+  cursorId: z.number().nullable(),
+  notifications: z.array(notificationSchema),
+  totalCount: z.number(),
+});
+
+export type Notification = z.infer<typeof notificationSchema>;
+export type NotificationsResponse = z.infer<typeof notificationsResponseSchema>;

--- a/packages/design-system/src/components/NotificationCard.tsx
+++ b/packages/design-system/src/components/NotificationCard.tsx
@@ -102,9 +102,6 @@ export default function NotificationCard({ content, onDelete, onClickDetail }: N
           </p>
         </div>
       </div>
-      <div className='flex justify-between text-xs'>
-        <p className='text-gray-300'>1분 전</p> {/* api에 따라 수정 예정 */}
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- #138

## 📌 작업 내용
<!-- 해당 PR의 변경 사항을 자세하게 적어주세요.-->

- 내 알림 목록 GET 요청
    - tanstack-query의 `useInfiniteQuery`와, `useIntersectionObserver` 사용해서 무한 스크롤을 구현했습니다.
    - zod를 통해 서버의 response를 유효성 검사를 했습니다.
- 내 알림 DELETE 요청
    - 특정 알림을 삭제할 수 있습니다.

## ✅ 체크리스트

- [x] PR 하기 전에 이슈에서 빼먹은건 없는지 확인했습니다
  - [x] 라벨 및 마일스톤을 사이드 탭에서 등록했습니다.
- [x] PR을 보내는 브랜치가 올바른지 확인했습니다.
- [x] 팀원들이 리뷰하기 쉽도록 설명을 자세하게 작성했습니다.
- [x] 변경사항을 충분히 테스트 했습니다.
- [x] (함수를 구현 했을 때) JSDoc을 양식에 맞춰서 작성했습니다.
- [x] 컨벤션에 맞게 구현했습니다.

## 📷 UI 변경 사항 (선택)
<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->

<img width="341" height="344" alt="image" src="https://github.com/user-attachments/assets/401761ef-dd88-4971-a5a7-54b50b6d2664" />

![알림 삭제](https://github.com/user-attachments/assets/bd261df0-c602-418a-98dc-30fec5399bbe)




## ❓무슨 문제가 발생했나요? (선택)

토스트 메시지가 알림창에 가려집니다..
이것도 z-index 문제 같아서 빠른 시일 내에 UI를 모두 완성하고 QA 해야할 것 같아요. 🥲

## 💬 기타 참고 사항 (선택)
<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->

1. 목업 데이터와 제가 갖고 있던 데이터들로 최대한 확인했지만, 애초에 실제 데이터로 충분히 확인하기에는 어려웠습니다..ㅎㅎ
    API 연결은 모두 확인했기 때문에, 나중에 데이터가 쌓이면 다시 한 번 확인해보겠습니다.

2. 모달이 완성되면 알림 삭제하기 전에 삭제 확인 모달을 한번 보여줘도 괜찮을 것 같습니다. 
    그런데 알림이 중요한 정보가 아니라서 삭제 확인 모달을 도입하는게 좋을지 고민입니다.

3. 데이터 패칭 함수와 tanstack-query 내용을 컴포넌트 안에 포함시키니 한 파일의 코드가 길어지는 것 같습니다. 
    데이터 요청 부분은 훅으로 분리하는게 좋을까요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **신규 기능**
  * 알림 목록을 무한 스크롤로 불러오는 기능이 추가되었습니다.
  * 알림 삭제 기능이 추가되었습니다.

* **버그 수정**
  * 알림 카드에서 임시로 표시되던 타임스탬프가 제거되었습니다.

* **스타일**
  * 프로필 이미지에 흰색 배경이 적용되었습니다.

* **기타**
  * 알림 관련 스키마와 타입이 추가되어 데이터 검증이 강화되었습니다.
  * 무한 스크롤을 위한 커스텀 훅이 도입되었습니다.
  * 개발 및 테스트를 위한 알림 모의 데이터가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->