### PR TITLE
로그인 & 회원가입 & 내 정보 페이지의 API 통신 리팩토링

### DIFF
--- a/apps/what-today/src/apis/auth.ts
+++ b/apps/what-today/src/apis/auth.ts
@@ -7,6 +7,7 @@ import {
   postProfileImageUrlResponseSchema,
   type SignInFormValues,
   signInSchema,
+  userSchema,
 } from '@/schemas/auth';
 import { generateTemporaryNickname } from '@/utils/generateTemporaryNickname';
 
@@ -80,7 +81,9 @@ export const patchMyProfile = async (
     ...(safePassword && { newPassword: safePassword }),
   };
 
-  return await axiosInstance.patch('users/me', body);
+  const response = await axiosInstance.patch('users/me', body);
+
+  return userSchema.parse(response.data);
 };
 
 /**

--- a/apps/what-today/src/apis/auth.ts
+++ b/apps/what-today/src/apis/auth.ts
@@ -1,3 +1,13 @@
+import {
+  kakaoSignInSchema,
+  kakaoSignUpSchema,
+  type LoginResponse,
+  loginResponseSchema,
+  postProfileImageFileSchema,
+  postProfileImageUrlResponseSchema,
+  type SignInFormValues,
+  signInSchema,
+} from '@/schemas/auth';
 import { generateTemporaryNickname } from '@/utils/generateTemporaryNickname';
 
 import axiosInstance from './axiosInstance';
@@ -6,36 +16,55 @@ import axiosInstance from './axiosInstance';
  * @description 로그인 요청 API
  * @returns accessToken + user
  */
-export const login = (email: string, password: string) => axiosInstance.post('auth/login', { email, password });
+export const login = async (input: SignInFormValues): Promise<LoginResponse> => {
+  const validated = signInSchema.parse(input);
+  const response = await axiosInstance.post('auth/login', validated);
+  return loginResponseSchema.parse(response.data);
+};
 
 /**
  * @description 카카오 로그인 (code → accessToken, refreshToken 반환)
  * @returns accessToken, refreshToken + user
  */
-export const signInWithKakao = (code: string) => {
-  return axiosInstance.post('oauth/sign-in/kakao', {
+export const signInWithKakao = async (code: string): Promise<LoginResponse> => {
+  const payload = kakaoSignInSchema.parse({
     redirectUri: import.meta.env.VITE_KAKAO_REDIRECT_URL,
     token: code,
   });
+
+  const response = await axiosInstance.post('oauth/sign-in/kakao', payload);
+
+  return loginResponseSchema.parse(response.data);
 };
 
 /**
  * @description 카카오 회원가입 (카카오 로그인 + 초기 nickName 포함)
  * @returns accessToken, refreshToken + user
  */
-export const signUpWithKakao = (code: string) => {
-  return axiosInstance.post('oauth/sign-up/kakao', {
+export const signUpWithKakao = async (code: string): Promise<LoginResponse> => {
+  /* 카카오 회원가입 확인 후 삭제할 코드입니다.
+  // const response = await axiosInstance.post('oauth/sign-up/kakao', {
+  //   nickname: generateTemporaryNickname(),
+  //   redirectUri: `${import.meta.env.VITE_KAKAO_REDIRECT_URL}/signup`,
+  //   token: code,
+  // });
+  */
+  const payload = kakaoSignUpSchema.parse({
     nickname: generateTemporaryNickname(),
     redirectUri: `${import.meta.env.VITE_KAKAO_REDIRECT_URL}/signup`,
     token: code,
   });
+
+  const response = await axiosInstance.post('oauth/sign-up/kakao', payload);
+
+  return loginResponseSchema.parse(response.data);
 };
 
 /**
  * @description 내 정보 수정 PATCH
  * @returns 변경된 user
  */
-export const patchMyProfile = (
+export const patchMyProfile = async (
   nickname?: string,
   profileImageUrl?: string | null | undefined,
   newPassword?: string,
@@ -51,7 +80,7 @@ export const patchMyProfile = (
     ...(safePassword && { newPassword: safePassword }),
   };
 
-  return axiosInstance.patch('users/me', body);
+  return await axiosInstance.patch('users/me', body);
 };
 
 /**
@@ -60,13 +89,17 @@ export const patchMyProfile = (
  * @param profileImageFile 업로드할 프로필 이미지 파일
  * @returns 프로필 이미지 url (string)
  */
-export const postProfileImageUrl = (profileImageFile: File) => {
-  const formData = new FormData();
-  formData.append('image', profileImageFile);
+export const postProfileImageUrl = async (profileImageFile: File): Promise<{ profileImageUrl: string }> => {
+  const validatedFile = postProfileImageFileSchema.parse(profileImageFile);
 
-  return axiosInstance.post('users/me/image', formData, {
+  const formData = new FormData();
+  formData.append('image', validatedFile);
+
+  const response = await axiosInstance.post('users/me/image', formData, {
     headers: {
       'Content-Type': 'multipart/form-data',
     },
   });
+
+  return postProfileImageUrlResponseSchema.parse(response.data);
 };

--- a/apps/what-today/src/apis/auth.ts
+++ b/apps/what-today/src/apis/auth.ts
@@ -7,6 +7,7 @@ import {
   postProfileImageUrlResponseSchema,
   type SignInFormValues,
   signInSchema,
+  type User,
   userSchema,
 } from '@/schemas/auth';
 import { generateTemporaryNickname } from '@/utils/generateTemporaryNickname';
@@ -21,6 +22,19 @@ export const login = async (input: SignInFormValues): Promise<LoginResponse> => 
   const validated = signInSchema.parse(input);
   const response = await axiosInstance.post('auth/login', validated);
   return loginResponseSchema.parse(response.data);
+};
+
+/**
+ * @description 회원가입 요청 API
+ * @returns accessToken + user
+ */
+export const signup = async (email: string, nickname: string, password: string): Promise<User> => {
+  const response = await axiosInstance.post('users', {
+    email,
+    nickname,
+    password,
+  });
+  return userSchema.parse(response.data);
 };
 
 /**

--- a/apps/what-today/src/apis/axiosInstance.ts
+++ b/apps/what-today/src/apis/axiosInstance.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 
+import { tokenResponseSchema } from '@/schemas/auth';
 import { useWhatTodayStore } from '@/stores';
 
 /**
@@ -96,7 +97,7 @@ axiosInstance.interceptors.response.use(
               },
             },
           );
-          const { accessToken, refreshToken: newRefreshToken } = response.data;
+          const { accessToken, refreshToken: newRefreshToken } = tokenResponseSchema.parse(response.data);
 
           useWhatTodayStore.getState().setAccessToken(accessToken);
           useWhatTodayStore.getState().setRefreshToken(newRefreshToken);

--- a/apps/what-today/src/apis/axiosInstance.ts
+++ b/apps/what-today/src/apis/axiosInstance.ts
@@ -43,7 +43,6 @@ axiosInstance.interceptors.request.use((config) => {
     const token = useWhatTodayStore.getState().accessToken;
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;
-      console.log('✔️ 엑세스 토큰을 추가했습니다!');
     }
   }
   return config;

--- a/apps/what-today/src/apis/user.ts
+++ b/apps/what-today/src/apis/user.ts
@@ -4,4 +4,8 @@ import axiosInstance from './axiosInstance';
  * @description 사용자 프로필 요청 API
  * @returns user
  */
-export const getMyProfile = () => axiosInstance.get('users/me');
+export const getMyProfile = async () => {
+  const response = await axiosInstance.get('users/me');
+
+  return response;
+};

--- a/apps/what-today/src/components/auth/EmailInput.tsx
+++ b/apps/what-today/src/components/auth/EmailInput.tsx
@@ -3,12 +3,12 @@ import { memo } from 'react';
 
 import type InputProps from '@/types/InputProps';
 
-function EmailInput({ value, onChange }: InputProps) {
+function EmailInput({ error, ...props }: InputProps) {
   return (
-    <Input.Root className='w-full'>
+    <Input.Root className='w-full' error={error}>
       <Input.Label>이메일</Input.Label>
       <Input.Wrapper>
-        <Input.Field placeholder='이메일을 입력해 주세요' type='email' value={value} onChange={onChange} />
+        <Input.Field {...props} placeholder='이메일을 입력해 주세요' type='email' />
       </Input.Wrapper>
       <Input.ErrorMessage />
     </Input.Root>

--- a/apps/what-today/src/components/auth/NicknameInput.tsx
+++ b/apps/what-today/src/components/auth/NicknameInput.tsx
@@ -3,12 +3,12 @@ import { memo } from 'react';
 
 import type InputProps from '@/types/InputProps';
 
-function NicknameInput({ value, onChange }: InputProps) {
+function NicknameInput({ error, ...props }: InputProps) {
   return (
-    <Input.Root className='w-full'>
+    <Input.Root className='w-full' error={error}>
       <Input.Label>닉네임</Input.Label>
       <Input.Wrapper>
-        <Input.Field placeholder='닉네임을 입력해 주세요' value={value} onChange={onChange} />
+        <Input.Field {...props} placeholder='닉네임을 입력해 주세요' />
       </Input.Wrapper>
       <Input.ErrorMessage />
     </Input.Root>

--- a/apps/what-today/src/components/auth/PasswordConfirmInput.tsx
+++ b/apps/what-today/src/components/auth/PasswordConfirmInput.tsx
@@ -3,19 +3,18 @@ import { memo, useState } from 'react';
 
 import type InputProps from '@/types/InputProps';
 
-function PasswordConfirmInput({ value, onChange }: InputProps) {
+function PasswordConfirmInput({ error, ...props }: InputProps) {
   const [isPasswordVisible, setIsPasswordVisible] = useState<boolean>(false);
 
   return (
-    <Input.Root className='w-full'>
+    <Input.Root className='w-full' error={error}>
       <Input.Label>비밀번호 확인</Input.Label>
       <Input.Wrapper>
         <Input.Field
           autoComplete='off'
           placeholder='비밀번호를 한 번 더 입력해 주세요'
           type={isPasswordVisible ? 'text' : 'password'}
-          value={value}
-          onChange={onChange}
+          {...props}
         />
         <span className='cursor-pointer' onClick={() => setIsPasswordVisible(!isPasswordVisible)}>
           <Input.Icon>{isPasswordVisible ? <EyeIcon /> : <EyeOffIcon className='size-17.5' />}</Input.Icon>

--- a/apps/what-today/src/components/auth/PasswordInput.tsx
+++ b/apps/what-today/src/components/auth/PasswordInput.tsx
@@ -3,19 +3,18 @@ import { memo, useState } from 'react';
 
 import type InputProps from '@/types/InputProps';
 
-function PasswordInput({ value, onChange }: InputProps) {
+function PasswordInput({ error, ...props }: InputProps) {
   const [isPasswordVisible, setIsPasswordVisible] = useState<boolean>(false);
 
   return (
-    <Input.Root className='w-full'>
+    <Input.Root className='w-full' error={error}>
       <Input.Label>비밀번호</Input.Label>
       <Input.Wrapper>
         <Input.Field
+          {...props}
           autoComplete='off'
           placeholder='비밀번호를 입력해 주세요'
           type={isPasswordVisible ? 'text' : 'password'}
-          value={value}
-          onChange={onChange}
         />
         <span className='cursor-pointer' onClick={() => setIsPasswordVisible(!isPasswordVisible)}>
           <Input.Icon>{isPasswordVisible ? <EyeIcon /> : <EyeOffIcon className='size-17.5' />}</Input.Icon>

--- a/apps/what-today/src/hooks/useAuth.ts
+++ b/apps/what-today/src/hooks/useAuth.ts
@@ -18,8 +18,7 @@ export default function useAuth() {
    * @throws 로그인 실패 시 예외를 발생시킵니다.
    */
   const loginUser = async (input: SignInFormValues) => {
-    const { email, password } = input;
-    const { data } = await login(email, password);
+    const data = await login(input);
     setAccessToken(data.accessToken);
     setRefreshToken(data.refreshToken);
   };

--- a/apps/what-today/src/hooks/useAuth.ts
+++ b/apps/what-today/src/hooks/useAuth.ts
@@ -1,27 +1,12 @@
-import { login } from '@/apis/auth';
 import { getMyProfile } from '@/apis/user';
-import type { SignInFormValues } from '@/schemas/auth';
 import { useWhatTodayStore } from '@/stores';
 
 /** useAuth
- * @description 로그인, 로그아웃, 사용자 정보 불러오기를 처리합니다.
- * @returns 인증 함수들 (loginUser, logoutUser, fetchMyProfile)
+ * @description 로그아웃을 처리합니다.
+ * @returns 인증 함수 (logoutUser)
  */
 export default function useAuth() {
-  const { setAccessToken, setRefreshToken, setUser, clearAuth } = useWhatTodayStore();
-
-  /** loginUser
-   * @description 로그인을 처리하며, 로그인 성공 시 accessToken과 refreshToken을 상태에 저장합니다.
-   *
-   * @param email - 사용자 이메일
-   * @param password - 사용자 비밀번호
-   * @throws 로그인 실패 시 예외를 발생시킵니다.
-   */
-  const loginUser = async (input: SignInFormValues) => {
-    const data = await login(input);
-    setAccessToken(data.accessToken);
-    setRefreshToken(data.refreshToken);
-  };
+  const { clearAuth, setUser } = useWhatTodayStore();
 
   /** logoutUser
    * @description 로그아웃을 처리하며, 전역 상태로 저장 중인 저장된 인증 정보를 모두 제거합니다.
@@ -38,5 +23,5 @@ export default function useAuth() {
     setUser(data);
   };
 
-  return { loginUser, logoutUser, fetchMyProfile };
+  return { logoutUser, fetchMyProfile };
 }

--- a/apps/what-today/src/hooks/useAuth.ts
+++ b/apps/what-today/src/hooks/useAuth.ts
@@ -1,5 +1,6 @@
 import { login } from '@/apis/auth';
 import { getMyProfile } from '@/apis/user';
+import type { SignInFormValues } from '@/schemas/auth';
 import { useWhatTodayStore } from '@/stores';
 
 /** useAuth
@@ -16,7 +17,8 @@ export default function useAuth() {
    * @param password - 사용자 비밀번호
    * @throws 로그인 실패 시 예외를 발생시킵니다.
    */
-  const loginUser = async (email: string, password: string) => {
+  const loginUser = async (input: SignInFormValues) => {
+    const { email, password } = input;
     const { data } = await login(email, password);
     setAccessToken(data.accessToken);
     setRefreshToken(data.refreshToken);

--- a/apps/what-today/src/hooks/useKakaoOAuth.ts
+++ b/apps/what-today/src/hooks/useKakaoOAuth.ts
@@ -44,8 +44,8 @@ export const useKakaoOAuth = ({ mode, onErrorRedirect }: UseKakaoOAuthOptions) =
       try {
         const response = mode === 'login' ? await signInWithKakao(code) : await signUpWithKakao(code);
 
-        setAccessToken(response.data.accessToken);
-        setRefreshToken(response.data.refreshToken);
+        setAccessToken(response.accessToken);
+        setRefreshToken(response.refreshToken);
         await fetchMyProfile();
         navigate('/');
       } catch (error) {

--- a/apps/what-today/src/hooks/useKakaoOAuth.ts
+++ b/apps/what-today/src/hooks/useKakaoOAuth.ts
@@ -1,5 +1,6 @@
+import { useMutation } from '@tanstack/react-query';
 import { useToast } from '@what-today/design-system';
-import { useCallback, useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import { signInWithKakao, signUpWithKakao } from '@/apis/auth';
@@ -35,40 +36,36 @@ export const useKakaoOAuth = ({ mode, onErrorRedirect }: UseKakaoOAuthOptions) =
   const { toast } = useToast();
   const requestSentRef = useRef(false);
 
-  const sendAuthRequest = useCallback(
-    async (code: string) => {
-      // 이미 요청을 보냈다면 중복 실행 방지
-      if (requestSentRef.current) return;
-      requestSentRef.current = true;
-
-      try {
-        const response = mode === 'login' ? await signInWithKakao(code) : await signUpWithKakao(code);
-
-        setAccessToken(response.accessToken);
-        setRefreshToken(response.refreshToken);
-        await fetchMyProfile();
-        navigate('/');
-      } catch (error) {
-        const message = error instanceof Error ? error.message : '인증에 실패했습니다.';
-        if (message === '이미 등록된 사용자입니다.' && mode === 'signup') {
-          toast({
-            title: '회원가입 오류',
-            description: '이미 가입한 계정이 있습니다. 로그인해주세요!',
-            type: 'error',
-          });
-          navigate(onErrorRedirect || '/login');
-        } else {
-          console.error('인증 오류 발생:', error);
-        }
+  const { mutate: kakaoAuthMutate } = useMutation({
+    mutationFn: async (code: string) => {
+      return mode === 'login' ? await signInWithKakao(code) : await signUpWithKakao(code);
+    },
+    onSuccess: async (response) => {
+      setAccessToken(response.accessToken);
+      setRefreshToken(response.refreshToken);
+      await fetchMyProfile();
+      navigate('/');
+    },
+    onError: (error) => {
+      const message = error instanceof Error ? error.message : '인증에 실패했습니다.';
+      if (message === '이미 등록된 사용자입니다.' && mode === 'signup') {
+        toast({
+          title: '회원가입 오류',
+          description: '이미 가입한 계정이 있습니다. 로그인해주세요!',
+          type: 'error',
+        });
+        navigate(onErrorRedirect || '/login');
+      } else {
+        console.error('인증 오류 발생:', error);
       }
     },
-    [mode, onErrorRedirect, setAccessToken, setRefreshToken, fetchMyProfile, navigate, toast],
-  );
+  });
 
   useEffect(() => {
     const code = searchParams.get('code');
-    if (!code) return;
+    if (!code || requestSentRef.current) return;
 
-    sendAuthRequest(code);
-  }, [searchParams, sendAuthRequest]);
+    requestSentRef.current = true;
+    kakaoAuthMutate(code);
+  }, [searchParams, kakaoAuthMutate]);
 };

--- a/apps/what-today/src/pages/login/index.tsx
+++ b/apps/what-today/src/pages/login/index.tsx
@@ -1,15 +1,21 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import useAuth from '@hooks/useAuth';
+import { useMutation } from '@tanstack/react-query';
 import { Button, ImageLogo, KaKaoIcon, TextLogo, useToast } from '@what-today/design-system';
-import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { Link, useNavigate } from 'react-router-dom';
 
+import { login } from '@/apis/auth';
 import EmailInput from '@/components/auth/EmailInput';
 import PasswordInput from '@/components/auth/PasswordInput';
 import { type SignInFormValues, signInSchema } from '@/schemas/auth';
+import { useWhatTodayStore } from '@/stores';
 
 export default function LoginPage() {
+  const navigate = useNavigate();
+  const { fetchMyProfile } = useAuth();
+  const { toast } = useToast();
+  const { setAccessToken, setRefreshToken } = useWhatTodayStore();
   const {
     register,
     handleSubmit,
@@ -23,37 +29,35 @@ export default function LoginPage() {
     },
   });
 
-  const navigate = useNavigate();
-  const { loginUser, fetchMyProfile } = useAuth();
-  const { toast } = useToast();
-
-  const [isLoginLoading, setIsLoginLoading] = useState(false);
-
   /** handleLogin
    * @description 로그인 요청을 보내고, 성공 시 토큰과 사용자 정보를 전역 상태로 저장합니다.
    * @throws 에러 발생 시 메시지를 토스트 메시지로 출력합니다.
    */
-  const onSubmit = async (data: SignInFormValues) => {
-    try {
-      setIsLoginLoading(true);
-      await loginUser({
-        email: data.email,
-        password: data.password,
-      });
+  const { mutate: loginMutate, isPending } = useMutation({
+    mutationFn: login,
+    onSuccess: async (response) => {
+      setAccessToken(response.accessToken);
+      setRefreshToken(response.refreshToken);
       await fetchMyProfile();
       navigate('/');
-    } catch (error) {
+    },
+    onError: (error) => {
       const message = error instanceof Error ? error.message : '로그인에 실패했습니다.';
       toast({
         title: '로그인 오류',
         description: message,
         type: 'error',
       });
-    } finally {
-      setIsLoginLoading(false);
-    }
+    },
+  });
+
+  const onSubmit = (data: SignInFormValues) => {
+    loginMutate(data);
   };
 
+  /** handleKakaoLogin
+   * @description 카카오 로그인 리다이렉트를 합니다.
+   */
   const handleKakaoLogin = () => {
     const clientId = import.meta.env.VITE_KAKAO_CLIENT_ID;
     const redirectUrl = import.meta.env.VITE_KAKAO_REDIRECT_URL ?? '';
@@ -95,7 +99,7 @@ export default function LoginPage() {
             <Button
               className='h-fit w-full rounded-xl py-10 font-normal'
               disabled={isSubmitting || !isValid}
-              loading={isLoginLoading}
+              loading={isPending}
               size='xl'
               type='submit'
             >
@@ -108,7 +112,7 @@ export default function LoginPage() {
             </div>
             <Button
               className='h-fit w-full rounded-xl py-10 font-normal'
-              loading={isLoginLoading}
+              loading={isPending}
               size='xl'
               variant='outline'
               onClick={handleKakaoLogin}

--- a/apps/what-today/src/pages/login/index.tsx
+++ b/apps/what-today/src/pages/login/index.tsx
@@ -1,31 +1,46 @@
+import { zodResolver } from '@hookform/resolvers/zod';
 import useAuth from '@hooks/useAuth';
 import { Button, ImageLogo, KaKaoIcon, TextLogo, useToast } from '@what-today/design-system';
 import { useState } from 'react';
+import { useForm } from 'react-hook-form';
 import { Link, useNavigate } from 'react-router-dom';
 
 import EmailInput from '@/components/auth/EmailInput';
 import PasswordInput from '@/components/auth/PasswordInput';
+import { type SignInFormValues, signInSchema } from '@/schemas/auth';
 
 export default function LoginPage() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting, isValid },
+  } = useForm<SignInFormValues>({
+    resolver: zodResolver(signInSchema),
+    mode: 'onChange',
+    defaultValues: {
+      email: '',
+      password: '',
+    },
+  });
+
   const navigate = useNavigate();
   const { loginUser, fetchMyProfile } = useAuth();
   const { toast } = useToast();
 
   const [isLoginLoading, setIsLoginLoading] = useState(false);
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
 
   /** handleLogin
    * @description 로그인 요청을 보내고, 성공 시 토큰과 사용자 정보를 전역 상태로 저장합니다.
    * @throws 에러 발생 시 메시지를 토스트 메시지로 출력합니다.
    */
-  const handleLogin = async () => {
+  const onSubmit = async (data: SignInFormValues) => {
     try {
       setIsLoginLoading(true);
-      await loginUser(email, password);
+      await loginUser({
+        email: data.email,
+        password: data.password,
+      });
       await fetchMyProfile();
-      setEmail('');
-      setPassword('');
       navigate('/');
     } catch (error) {
       const message = error instanceof Error ? error.message : '로그인에 실패했습니다.';
@@ -65,36 +80,31 @@ export default function LoginPage() {
   return (
     <div className='flex min-h-screen w-screen min-w-300 flex-col items-center justify-center px-[5vw] py-50 md:py-80'>
       <div className='flex h-fit w-full flex-col items-center justify-center gap-32 md:w-500'>
-        <div className='flex flex-col items-center gap-12'>
+        <Link className='flex flex-col items-center gap-12' to='/'>
           <ImageLogo className='size-100 md:size-140' />
           <TextLogo className='h-fit w-130 md:w-180' />
-        </div>
+        </Link>
 
-        <form
-          className='flex w-full flex-col items-center justify-center gap-32'
-          onSubmit={(e) => {
-            e.preventDefault();
-            handleLogin();
-          }}
-        >
+        <form className='flex w-full flex-col items-center justify-center gap-32' onSubmit={handleSubmit(onSubmit)}>
           <div className='flex w-full flex-col gap-12'>
-            <EmailInput value={email} onChange={(e) => setEmail(e.target.value)} />
-            <PasswordInput value={password} onChange={(e) => setPassword(e.target.value)} />
+            <EmailInput {...register('email')} error={errors.email?.message} />
+            <PasswordInput {...register('password')} error={errors.password?.message} />
           </div>
 
           <div className='flex w-full flex-col gap-12'>
             <Button
               className='h-fit w-full rounded-xl py-10 font-normal'
+              disabled={isSubmitting || !isValid}
               loading={isLoginLoading}
               size='xl'
               type='submit'
             >
               로그인
             </Button>
-            <div className='flex w-full items-center text-gray-300'>
-              <div className='h-1 flex-1 bg-gray-300' />
+            <div className='flex w-full items-center text-gray-400'>
+              <div className='h-1 flex-1 bg-gray-100' />
               <p className='text-md px-12'>or</p>
-              <div className='h-1 flex-1 bg-gray-300' />
+              <div className='h-1 flex-1 bg-gray-100' />
             </div>
             <Button
               className='h-fit w-full rounded-xl py-10 font-normal'
@@ -112,7 +122,10 @@ export default function LoginPage() {
         <div className='flex items-center gap-12 text-lg text-gray-500'>
           <p>회원이 아니신가요?</p>
           <Link to='/signup'>
-            <Button className='m-0 h-fit w-fit p-0 text-lg font-normal underline' variant='none'>
+            <Button
+              className='text-primary-500 m-0 h-fit w-fit p-0 text-lg font-normal underline underline-offset-3'
+              variant='none'
+            >
               회원가입하기
             </Button>
           </Link>

--- a/apps/what-today/src/pages/mypage/edit-profile/index.tsx
+++ b/apps/what-today/src/pages/mypage/edit-profile/index.tsx
@@ -3,6 +3,7 @@ import { Button, ChevronIcon, ProfileImageInput, useToast } from '@what-today/de
 import { useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
+import z from 'zod';
 
 import { patchMyProfile, postProfileImageUrl } from '@/apis/auth';
 import NicknameInput from '@/components/auth/NicknameInput';
@@ -105,7 +106,7 @@ export default function EditProfilePage() {
       if (isBlobUrl) {
         const file = await stringToFile(profileImageUrl, 'profile.jpg');
         const imageUploadRes = await postProfileImageUrl(file);
-        uploadedImageUrl = imageUploadRes.data.profileImageUrl;
+        uploadedImageUrl = imageUploadRes.profileImageUrl;
       } else if (isReset) {
         uploadedImageUrl = null;
       } else if (!isOriginalImage) {
@@ -127,7 +128,14 @@ export default function EditProfilePage() {
         handleLogout();
       }
     } catch (error) {
-      const message = error instanceof Error ? error.message : '프로필 수정에 실패했습니다.';
+      let message = '프로필 수정에 실패했습니다.';
+
+      if (error instanceof z.ZodError) {
+        message = error.errors[0]?.message ?? message;
+      } else if (error instanceof Error) {
+        message = error.message;
+      }
+
       toast({
         title: '프로필 수정 실패',
         description: message,

--- a/apps/what-today/src/pages/mypage/edit-profile/index.tsx
+++ b/apps/what-today/src/pages/mypage/edit-profile/index.tsx
@@ -1,6 +1,6 @@
 import { zodResolver } from '@hookform/resolvers/zod';
+import { useMutation } from '@tanstack/react-query';
 import { Button, ChevronIcon, ProfileImageInput, useToast } from '@what-today/design-system';
-import { useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import z from 'zod';
@@ -37,9 +37,39 @@ const stringToFile = async (url: string, filename = 'image.jpg'): Promise<File> 
   }
 };
 
+/** resolveProfileImageUrl
+ * @description 폼에서 넘어온 profileImageUrl을 기반으로 서버에 보낼 최종 이미지 URL을 반환
+ * @returns 업로드된 URL 문자열 | null (초기화) | undefined (변경 없음)
+ */
+async function resolveProfileImageUrl({
+  profileImageUrl,
+  originalImageUrl,
+}: {
+  profileImageUrl: string;
+  originalImageUrl?: string | null;
+}): Promise<string | null | undefined> {
+  if (profileImageUrl.startsWith('blob:')) {
+    const file = await stringToFile(profileImageUrl, 'profile.jpg');
+    const { profileImageUrl: uploadedUrl } = await postProfileImageUrl(file);
+    return uploadedUrl;
+  }
+
+  if (profileImageUrl === '') {
+    return null; // 이미지 초기화
+  }
+
+  if (profileImageUrl !== originalImageUrl) {
+    return profileImageUrl; // 새로운 이미지 URL
+  }
+
+  return undefined; // 변경 없음
+}
+
 export default function EditProfilePage() {
   const { user, setUser } = useWhatTodayStore();
-
+  const navigate = useNavigate();
+  const { logoutUser } = useAuth();
+  const { toast } = useToast();
   const {
     control,
     register,
@@ -57,11 +87,6 @@ export default function EditProfilePage() {
       passwordConfirm: '',
     },
   });
-
-  const navigate = useNavigate();
-  const { logoutUser } = useAuth();
-  const { toast } = useToast();
-  const [isEditProfileLoading] = useState(false);
   const watchedPassword = watch('password');
 
   /**
@@ -95,44 +120,39 @@ export default function EditProfilePage() {
   /**
    * @description 프로필 사진 or 닉네임 or 비밀번호를 수정하는 API를 요청합니다. 실패시 에러 토스트 메시지를 보여줍니다.
    */
-  const onSubmit = async (data: UpdateMyProfileFormValues) => {
-    try {
-      const profileImageUrl = data.profileImageUrl ?? '';
-      let uploadedImageUrl: string | null | undefined = undefined;
-      const isBlobUrl = profileImageUrl.startsWith('blob:');
-      const isReset = profileImageUrl === '';
-      const isOriginalImage = profileImageUrl === user?.profileImageUrl;
+  const { mutate: updateProfileMutate, isPending } = useMutation({
+    mutationFn: async (data: UpdateMyProfileFormValues) => {
+      const uploadedImageUrl = await resolveProfileImageUrl({
+        profileImageUrl: data.profileImageUrl ?? '',
+        originalImageUrl: user?.profileImageUrl,
+      });
 
-      if (isBlobUrl) {
-        const file = await stringToFile(profileImageUrl, 'profile.jpg');
-        const imageUploadRes = await postProfileImageUrl(file);
-        uploadedImageUrl = imageUploadRes.profileImageUrl;
-      } else if (isReset) {
-        uploadedImageUrl = null;
-      } else if (!isOriginalImage) {
-        uploadedImageUrl = profileImageUrl;
-      }
+      const updatedUser = await patchMyProfile(data.nickname, uploadedImageUrl, data.password);
 
-      const response = await patchMyProfile(data.nickname, uploadedImageUrl, data.password);
-
+      return {
+        updatedUser,
+        passwordChanged: Boolean(data.password),
+      };
+    },
+    onSuccess: ({ updatedUser, passwordChanged }) => {
       toast({
         title: '내 정보 변경 성공',
         description: '프로필이 성공적으로 업데이트되었습니다.',
         type: 'success',
       });
-      setUser(response);
+      setUser(updatedUser);
       reset({
-        nickname: response.nickname,
-        profileImageUrl: response.profileImageUrl ?? '',
+        nickname: updatedUser.nickname,
+        profileImageUrl: updatedUser.profileImageUrl ?? '',
         password: '',
         passwordConfirm: '',
       });
 
-      // 비밀번호가 수정되었다면 로그아웃 후 로그인 페이지로 이동 (재로그인 유도)
-      if (data.password) {
+      if (passwordChanged) {
         handleLogout();
       }
-    } catch (error) {
+    },
+    onError: (error) => {
       let message = '프로필 수정에 실패했습니다.';
 
       if (error instanceof z.ZodError) {
@@ -146,7 +166,11 @@ export default function EditProfilePage() {
         description: message,
         type: 'error',
       });
-    }
+    },
+  });
+
+  const onSubmit = (data: UpdateMyProfileFormValues) => {
+    updateProfileMutate(data);
   };
 
   return (
@@ -184,7 +208,7 @@ export default function EditProfilePage() {
         <div className='flex w-full max-w-640 justify-center gap-12'>
           <Button
             className='h-fit w-auto rounded-xl py-10 font-normal'
-            loading={isEditProfileLoading}
+            loading={isPending}
             size='xl'
             type='reset'
             variant='outline'
@@ -194,7 +218,7 @@ export default function EditProfilePage() {
           <Button
             className='h-fit w-auto rounded-xl py-10 font-normal'
             disabled={isSubmitting || !isValid}
-            loading={isEditProfileLoading}
+            loading={isPending}
             size='xl'
             type='submit'
           >

--- a/apps/what-today/src/pages/mypage/edit-profile/index.tsx
+++ b/apps/what-today/src/pages/mypage/edit-profile/index.tsx
@@ -120,8 +120,13 @@ export default function EditProfilePage() {
         description: '프로필이 성공적으로 업데이트되었습니다.',
         type: 'success',
       });
-      setUser(response.data);
-      reset(response.data);
+      setUser(response);
+      reset({
+        nickname: response.nickname,
+        profileImageUrl: response.profileImageUrl ?? '',
+        password: '',
+        passwordConfirm: '',
+      });
 
       // 비밀번호가 수정되었다면 로그아웃 후 로그인 페이지로 이동 (재로그인 유도)
       if (data.password) {

--- a/apps/what-today/src/pages/signup/index.tsx
+++ b/apps/what-today/src/pages/signup/index.tsx
@@ -1,5 +1,7 @@
+import { zodResolver } from '@hookform/resolvers/zod';
 import { Button, ImageLogo, KaKaoIcon, TextLogo, useToast } from '@what-today/design-system';
 import { useState } from 'react';
+import { useForm } from 'react-hook-form';
 import { Link, useNavigate } from 'react-router-dom';
 
 import axiosInstance from '@/apis/axiosInstance';
@@ -7,28 +9,39 @@ import EmailInput from '@/components/auth/EmailInput';
 import NicknameInput from '@/components/auth/NicknameInput';
 import PasswordConfirmInput from '@/components/auth/PasswordConfirmInput';
 import PasswordInput from '@/components/auth/PasswordInput';
+import { type SignUpFormValues, signUpSchema } from '@/schemas/auth';
 
 export default function SignupPage() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting, isValid },
+  } = useForm<SignUpFormValues>({
+    resolver: zodResolver(signUpSchema),
+    mode: 'onChange',
+    defaultValues: {
+      email: '',
+      nickname: '',
+      password: '',
+      passwordConfirm: '',
+    },
+  });
+
   const navigate = useNavigate();
   const { toast } = useToast();
-
   const [isSignupLoading, setIsSignupLoading] = useState(false);
-  const [email, setEmail] = useState('');
-  const [nickname, setNickname] = useState('');
-  const [password, setPassword] = useState('');
-  const [passwordConfirm, setPasswordConfirm] = useState('');
 
   /** handleSignup
    * @description 회원가입 요청을 보내고, 성공시 로그인 페이지로 리다이렉트합니다.
    * @throws 에러 발생 시 메시지를 토스트 메시지로 출력합니다.
    */
-  const handleSignup = async () => {
+  const onSubmit = async (data: SignUpFormValues) => {
     try {
       setIsSignupLoading(true);
       await axiosInstance.post('users', {
-        email,
-        nickname,
-        password,
+        email: data.email,
+        nickname: data.nickname,
+        password: data.password,
       });
       toast({
         title: '회원가입 성공',
@@ -75,38 +88,33 @@ export default function SignupPage() {
   return (
     <div className='flex min-h-screen w-screen min-w-300 flex-col items-center justify-center px-[5vw] py-50 md:py-80'>
       <div className='flex h-fit w-full flex-col items-center justify-center gap-32 md:w-500'>
-        <div className='flex flex-col items-center gap-12'>
+        <Link className='flex flex-col items-center gap-12' to='/'>
           <ImageLogo className='size-100 md:size-140' />
           <TextLogo className='h-fit w-130 md:w-180' />
-        </div>
+        </Link>
 
-        <form
-          className='flex w-full flex-col items-center justify-center gap-32'
-          onSubmit={(e) => {
-            e.preventDefault();
-            handleSignup();
-          }}
-        >
+        <form className='flex w-full flex-col items-center justify-center gap-32' onSubmit={handleSubmit(onSubmit)}>
           <div className='flex w-full flex-col gap-12'>
-            <EmailInput value={email} onChange={(e) => setEmail(e.target.value)} />
-            <NicknameInput value={nickname} onChange={(e) => setNickname(e.target.value)} />
-            <PasswordInput value={password} onChange={(e) => setPassword(e.target.value)} />
-            <PasswordConfirmInput value={passwordConfirm} onChange={(e) => setPasswordConfirm(e.target.value)} />
+            <EmailInput {...register('email')} error={errors.email?.message} />
+            <NicknameInput {...register('nickname')} error={errors.nickname?.message} />
+            <PasswordInput {...register('password')} error={errors.password?.message} />
+            <PasswordConfirmInput {...register('passwordConfirm')} error={errors.passwordConfirm?.message} />
           </div>
 
           <div className='flex w-full flex-col gap-12'>
             <Button
               className='h-fit w-full rounded-xl py-10 font-normal'
+              disabled={isSubmitting || !isValid}
               loading={isSignupLoading}
               size='xl'
               type='submit'
             >
               회원가입
             </Button>
-            <div className='flex w-full items-center text-gray-300'>
-              <div className='h-1 flex-1 bg-gray-300' />
+            <div className='flex w-full items-center text-gray-400'>
+              <div className='h-1 flex-1 bg-gray-100' />
               <p className='text-md px-12'>SNS 계정으로 회원가입하기</p>
-              <div className='h-1 flex-1 bg-gray-300' />
+              <div className='h-1 flex-1 bg-gray-100' />
             </div>
             <Button
               className='h-fit w-full rounded-xl py-10 font-normal'
@@ -124,7 +132,10 @@ export default function SignupPage() {
         <div className='flex items-center gap-12 text-lg text-gray-500'>
           <p>회원이신가요?</p>
           <Link to='/login'>
-            <Button className='m-0 h-fit w-fit p-0 text-lg font-normal underline' variant='none'>
+            <Button
+              className='text-primary-500 m-0 h-fit w-fit p-0 text-lg font-normal underline underline-offset-3'
+              variant='none'
+            >
               로그인하기
             </Button>
           </Link>

--- a/apps/what-today/src/schemas/auth.ts
+++ b/apps/what-today/src/schemas/auth.ts
@@ -67,6 +67,17 @@ export type LoginResponse = z.infer<typeof loginResponseSchema>;
 
 /**
  * From server
+ * @description 토큰 재발급 응답
+ */
+export const tokenResponseSchema = z.object({
+  accessToken: z.string(),
+  refreshToken: z.string(),
+});
+
+export type TokenResponse = z.infer<typeof tokenResponseSchema>;
+
+/**
+ * From server
  * @description 카카오 로그인 요청
  */
 export const kakaoSignInSchema = z.object({

--- a/apps/what-today/src/schemas/auth.ts
+++ b/apps/what-today/src/schemas/auth.ts
@@ -5,15 +5,15 @@ import { z } from 'zod';
  * @description 사용자 정보 스키마
  */
 export const userSchema = z.object({
-  id: z.number().int().positive(),
+  id: z.number(),
   email: z.string().email(),
   nickname: z.string(),
-  profileImageUrl: z.string().url().nullable(),
+  profileImageUrl: z.string().nullable(),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),
 });
 
-export type Activity = z.infer<typeof userSchema>;
+export type User = z.infer<typeof userSchema>;
 
 /**
  * To server
@@ -54,6 +54,41 @@ export const signInSchema = z.object({
 export type SignInFormValues = z.infer<typeof signInSchema>;
 
 /**
+ * From server
+ * @description 로그인 응답
+ */
+export const loginResponseSchema = z.object({
+  user: userSchema,
+  accessToken: z.string(),
+  refreshToken: z.string(),
+});
+
+export type LoginResponse = z.infer<typeof loginResponseSchema>;
+
+/**
+ * From server
+ * @description 카카오 로그인 요청
+ */
+export const kakaoSignInSchema = z.object({
+  redirectUri: z.string().url(),
+  token: z.string().min(1, '토큰이 필요합니다.'),
+});
+
+export type KakaoSignInRequest = z.infer<typeof kakaoSignInSchema>;
+
+/**
+ * From server
+ * @description 카카오 회원가입 요청
+ */
+export const kakaoSignUpSchema = z.object({
+  nickname: z.string(),
+  redirectUri: z.string().url(),
+  token: z.string().min(1, '토큰이 필요합니다.'),
+});
+
+export type KakaoSignUpRequest = z.infer<typeof kakaoSignUpSchema>;
+
+/**
  * To server
  * @description 내 정보 수정 요청
  */
@@ -64,12 +99,7 @@ export const updateMyProfileSchema = z
       .min(1, { message: '닉네임을 입력해 주세요.' })
       .max(10, { message: '닉네임은 10자 이내로 입력해주세요.' })
       .optional(),
-    profileImageUrl: z
-      .union([
-        z.string().url(),
-        z.literal(''), // 빈 문자열 허용
-      ])
-      .optional(),
+    profileImageUrl: z.union([z.string().url(), z.literal('')]).optional(),
     password: z.string().optional(),
     passwordConfirm: z.string().optional(),
   })
@@ -106,3 +136,33 @@ export const updateMyProfileSchema = z
   });
 
 export type UpdateMyProfileFormValues = z.infer<typeof updateMyProfileSchema>;
+
+/**
+ * To server
+ * @description 프로필 이미지 URL 생성 요청
+ */
+
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+const ACCEPTED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
+
+export const postProfileImageFileSchema = z
+  .instanceof(File)
+  .refine((file) => file.size <= MAX_FILE_SIZE, {
+    message: '파일 크기는 5MB 이하여야 합니다.',
+  })
+  .refine((file) => ACCEPTED_IMAGE_TYPES.includes(file.type), {
+    message: '지원되지 않는 이미지 형식입니다.',
+  });
+
+export type ProfileImageUrlValues = z.infer<typeof postProfileImageFileSchema>;
+
+/**
+ * From server
+ * @description 프로필 이미지 URL 응답
+ */
+
+export const postProfileImageUrlResponseSchema = z.object({
+  profileImageUrl: z.string().url(),
+});
+
+export type PostProfileImageUrlResponse = z.infer<typeof postProfileImageUrlResponseSchema>;

--- a/apps/what-today/src/schemas/auth.ts
+++ b/apps/what-today/src/schemas/auth.ts
@@ -19,7 +19,7 @@ export type User = z.infer<typeof userSchema>;
  * To server
  * @description 회원가입 요청
  */
-export const signUpSchema = z
+export const signUpFormSchema = z
   .object({
     email: z.string().min(1, { message: '이메일을 입력해 주세요.' }).email({ message: '이메일 형식이 아닙니다.' }),
     nickname: z
@@ -37,7 +37,7 @@ export const signUpSchema = z
     path: ['passwordConfirm'],
   });
 
-export type SignUpFormValues = z.infer<typeof signUpSchema>;
+export type SignUpFormValues = z.infer<typeof signUpFormSchema>;
 
 /**
  * To server

--- a/apps/what-today/src/schemas/auth.ts
+++ b/apps/what-today/src/schemas/auth.ts
@@ -52,3 +52,57 @@ export const signInSchema = z.object({
 });
 
 export type SignInFormValues = z.infer<typeof signInSchema>;
+
+/**
+ * To server
+ * @description 내 정보 수정 요청
+ */
+export const updateMyProfileSchema = z
+  .object({
+    nickname: z
+      .string()
+      .min(1, { message: '닉네임을 입력해 주세요.' })
+      .max(10, { message: '닉네임은 10자 이내로 입력해주세요.' })
+      .optional(),
+    profileImageUrl: z
+      .union([
+        z.string().url(),
+        z.literal(''), // 빈 문자열 허용
+      ])
+      .optional(),
+    password: z.string().optional(),
+    passwordConfirm: z.string().optional(),
+  })
+  .superRefine((data, ctx) => {
+    const password = data.password?.trim();
+
+    // password가 1글자 이상 입력된 경우만 검사
+    if (password && password.length > 0) {
+      if (password.length < 8) {
+        ctx.addIssue({
+          path: ['password'],
+          code: z.ZodIssueCode.too_small,
+          minimum: 8,
+          type: 'string',
+          inclusive: true,
+          message: '비밀번호는 8자 이상이어야 합니다.',
+        });
+      }
+
+      if (!data.passwordConfirm || data.passwordConfirm.trim() === '') {
+        ctx.addIssue({
+          path: ['passwordConfirm'],
+          code: z.ZodIssueCode.custom,
+          message: '비밀번호 확인을 입력해 주세요.',
+        });
+      } else if (password !== data.passwordConfirm) {
+        ctx.addIssue({
+          path: ['passwordConfirm'],
+          code: z.ZodIssueCode.custom,
+          message: '비밀번호가 일치하지 않습니다.',
+        });
+      }
+    }
+  });
+
+export type UpdateMyProfileFormValues = z.infer<typeof updateMyProfileSchema>;

--- a/apps/what-today/src/schemas/auth.ts
+++ b/apps/what-today/src/schemas/auth.ts
@@ -1,0 +1,54 @@
+import { z } from 'zod';
+
+/**
+ * From server
+ * @description 사용자 정보 스키마
+ */
+export const userSchema = z.object({
+  id: z.number().int().positive(),
+  email: z.string().email(),
+  nickname: z.string(),
+  profileImageUrl: z.string().url().nullable(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+});
+
+export type Activity = z.infer<typeof userSchema>;
+
+/**
+ * To server
+ * @description 회원가입 요청
+ */
+export const signUpSchema = z
+  .object({
+    email: z.string().min(1, { message: '이메일을 입력해 주세요.' }).email({ message: '이메일 형식이 아닙니다.' }),
+    nickname: z
+      .string()
+      .min(1, { message: '닉네임을 입력해 주세요.' })
+      .max(10, { message: '닉네임은 10자 이내로 입력해주세요.' }),
+    password: z
+      .string()
+      .min(1, { message: '비밀번호를 입력해 주세요.' })
+      .min(8, { message: '비밀번호는 8자 이상이어야 합니다.' }),
+    passwordConfirm: z.string().min(1, { message: '비밀번호 확인을 입력해 주세요.' }),
+  })
+  .refine((data) => data.password === data.passwordConfirm, {
+    message: '비밀번호가 일치하지 않습니다.',
+    path: ['passwordConfirm'],
+  });
+
+export type SignUpFormValues = z.infer<typeof signUpSchema>;
+
+/**
+ * To server
+ * @description 로그인 요청
+ */
+export const signInSchema = z.object({
+  email: z.string().min(1, { message: '이메일을 입력해 주세요.' }).email({ message: '이메일 형식이 아닙니다.' }),
+  password: z
+    .string()
+    .min(1, { message: '비밀번호를 입력해 주세요.' })
+    .min(8, { message: '비밀번호는 8자 이상이어야 합니다.' }),
+});
+
+export type SignInFormValues = z.infer<typeof signInSchema>;

--- a/apps/what-today/src/types/InputProps.ts
+++ b/apps/what-today/src/types/InputProps.ts
@@ -1,4 +1,3 @@
 export default interface InputProps {
-  value: string;
-  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  error?: string;
 }

--- a/packages/design-system/src/components/input/InputField.tsx
+++ b/packages/design-system/src/components/input/InputField.tsx
@@ -11,11 +11,11 @@ import type { InputFieldProps } from './type';
  * @example
  * <Input.Field value={value} onChange={onChange} placeholder="이메일 입력" />
  */
-function InputField({ value, onChange, ref, type = 'text', className, ...props }: InputFieldProps) {
+function InputField({ value, onChange, type = 'text', className, ...props }: InputFieldProps) {
   const { error, id, setIsFocused, disabled } = useInputContext();
   return (
     <input
-      ref={ref}
+      {...props}
       aria-describedby={error ? `${id}-error` : undefined}
       aria-invalid={!!error}
       className={twMerge('flex-1 placeholder:text-gray-400 focus:outline-none', className)}

--- a/packages/design-system/src/components/input/InputWrapper.tsx
+++ b/packages/design-system/src/components/input/InputWrapper.tsx
@@ -14,9 +14,9 @@ function InputWrapper({ className, children }: InputSubComponentProps) {
 
   const BASE_CLASSNAME = twJoin(
     'flex items-center gap-8 rounded-xl border px-20 py-10 bg-white',
-    error ? 'border-red-500' : 'border-gray-100',
     isFocused && 'border-gray-400',
     disabled && 'cursor-not-allowed',
+    error ? 'border-red-500' : 'border-gray-100',
   );
 
   return <div className={twMerge(BASE_CLASSNAME, className)}>{children}</div>;


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- #123

## 📌 작업 내용
<!-- 해당 PR의 변경 사항을 자세하게 적어주세요.-->

1. **api request, response에 zod를 적용했습니다.**
    - zod + react-hook-form로 미리 유효성 검사한 request는 API단에서 zod 검사를 생략했습니다.
2. **auth 관련 입력폼들에 react-hook-form을 적용했습니다.**
    - 프로필 이미지 URL 생성을 요청하는 입력폼은 다른 데이터들과 함께 서버로 전송될 때 한 번 더 검사하므로 생략했습니다.
3. **한 페이지를 담당하는 api request에 tanstack-query를 적용했습니다.**
    - `/user/me` 요청 제외
       사용자 정보를 받아오는 /users/me는 로그인 요청 tanstack-query hook 내부에서 실행됩니다. 
       이때 tanstack-query hook 내부에서 tanstack-query hook이 다시 실행되는 중첩 구조가 불가능하기 때문입니다.
    -  `/users/me/image` 요청 제외
       이 요청은 프로필 이미지 수정 페이지와 같이 하나의 페이지에서 요청되는게 아니라, 서버에 요청할 이미지 데이터를 한 번 변환하는 과정의 일부로 쓰입니다.
       따라서 UI에 직접적인 영향을 주지 않아 캐싱이나 상태 관리를 할 필요가 없어서 생략했습니다.

## ✅ 체크리스트

- [x] PR 하기 전에 이슈에서 빼먹은건 없는지 확인했습니다
  - [x] 라벨 및 마일스톤을 사이드 탭에서 등록했습니다.
- [x] PR을 보내는 브랜치가 올바른지 확인했습니다.
- [x] 팀원들이 리뷰하기 쉽도록 설명을 자세하게 작성했습니다.
- [x] 변경사항을 충분히 테스트 했습니다.
- [x] (함수를 구현 했을 때) JSDoc을 양식에 맞춰서 작성했습니다.
- [x] 컨벤션에 맞게 구현했습니다.

## 📷 UI 변경 사항 (선택)
<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->

내부 API 통신 코드를 리팩토링 했기 때문에 바뀐 UI는 없습니다.

## ❓무슨 문제가 발생했나요? (선택)

- 제가 생각보다 많은 API 요청을 사용했더라구요..?
  그래서 여러 기술을 한 번에 도입하려고 하니까 단계별로 진행했음에도 많이 어려웠습니다...🥲

## 💬 기타 참고 사항 (선택)
<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->

- tanstack-query를 어떻게 관리할 것인가(컴포넌트 내부에 작성 vs 파일로 분리) 다시 얘기를 해봐도 좋을 것 같아요..!
- 지금 코드가 많이 더럽고 복잡해서, 가독성&컨벤션 측면에서 리팩토링할 예정입니다. (이 PR에 업데이트할 예정입니다.) 
  하지만 혹시 API 통신 리팩토링 하실 때 예시가 될까 싶어 미리 PR 올렸습니다..! 
- 혹시 QA 하실 때 오류나는 부분이 있으면 피드백 부탁드립니다!
