### PR TITLE
UI 통일을 위한 프로젝트 세팅

### DIFF
--- a/apps/what-today/src/index.css
+++ b/apps/what-today/src/index.css
@@ -55,5 +55,29 @@
   html {
     font-family: 'Pretendard', system-ui, sans-serif;
     word-break: keep-all;
+    color: var(--color-gray-950);
+    background-color: white;
+  }
+}
+
+@layer components {
+  /* 제목 (32px PC/Tablet, 24px Mobile) */
+  .title-text {
+    @apply text-[1.5rem] font-bold md:text-[2rem]; /* 24px → 32px */
+  }
+
+  /* 소제목 (24px PC/Tablet, 20px Mobile) */
+  .subtitle-text {
+    @apply text-[1.25rem] font-bold md:text-[1.5rem]; /* 20px → 24px */
+  }
+
+  /* 본문 (16px PC/Tablet, 14px Mobile) */
+  .body-text {
+    @apply text-[0.875rem] font-normal md:text-[1rem]; /* 14px → 16px */
+  }
+
+  /* 캡션 (14px PC/Tablet, 12px Mobile) */
+  .caption-text {
+    @apply text-[0.75rem] font-normal md:text-[0.875rem]; /* 12px → 14px */
   }
 }

--- a/packages/design-system/src/components/button/index.tsx
+++ b/packages/design-system/src/components/button/index.tsx
@@ -13,11 +13,12 @@ const BUTTON_VARIANTS = {
 };
 
 const BUTTON_SIZE = {
-  xl: 'w-640 h-54 px-40 py-14 text-lg font-bold rounded-2xl',
-  lg: 'w-410 h-51 px-12 py-16 text-lg rounded-xl',
-  md: 'w-232 h-37 px-10 py-10 text-md rounded-lg',
-  sm: 'w-138 h-47 px-40 py-14 text-lg rounded-[14px]',
-  xs: 'w-120 h-41 px-40 py-12 text-md font-bold rounded-xl',
+  xl: 'w-640 h-54 px-40 py-14 ',
+  lg: 'w-410 h-51 px-12 py-16',
+  md: 'w-232 h-37 px-10 py-10',
+  sm: 'w-138 h-47 px-40 py-14',
+  xs: 'w-120 h-41 px-40 py-12',
+  none: 'w-fit h-fit p-0',
 };
 
 function LoadingButton({ className, children }: { className: string; children: React.ReactNode }) {
@@ -53,7 +54,7 @@ export default function Button({
   };
 
   const buttonClassNames = twMerge(
-    'inline-flex cursor-pointer items-center justify-center rounded-sm font-medium whitespace-nowrap gap-6',
+    'inline-flex cursor-pointer items-center justify-center rounded-xl whitespace-nowrap gap-6',
     'disabled:cursor-not-allowed disabled:border-none disabled:bg-gray-200 disabled:text-gray-50',
     BUTTON_VARIANTS[variant],
     BUTTON_SIZE[size],

--- a/packages/design-system/src/index.css
+++ b/packages/design-system/src/index.css
@@ -55,6 +55,8 @@
   html {
     font-family: 'Pretendard', system-ui, sans-serif;
     word-break: keep-all;
+    color: var(--color-gray-950);
+    background-color: white;
   }
 
   .prose pre {
@@ -67,5 +69,27 @@
 
   .prose pre code {
     padding: 1.5rem !important;
+  }
+}
+
+@layer components {
+  /* 제목 (32px PC/Tablet, 24px Mobile) */
+  .title-text {
+    @apply text-[1.5rem] font-bold md:text-[2rem]; /* 24px → 32px */
+  }
+
+  /* 소제목 (24px PC/Tablet, 20px Mobile) */
+  .subtitle-text {
+    @apply text-[1.25rem] font-bold md:text-[1.5rem]; /* 20px → 24px */
+  }
+
+  /* 본문 (16px PC/Tablet, 14px Mobile) */
+  .body-text {
+    @apply text-[0.875rem] font-normal md:text-[1rem]; /* 14px → 16px */
+  }
+
+  /* 캡션 (14px PC/Tablet, 12px Mobile) */
+  .caption-text {
+    @apply text-[0.75rem] font-normal md:text-[0.875rem]; /* 12px → 14px */
   }
 }


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- #173 

## 📌 작업 내용
<!-- 해당 PR의 변경 사항을 자세하게 적어주세요.-->

### @html 세팅
- `color: var(--color-gray-950);` 를 추가해서 기본 글씨색을 적용했습니다.
- `background-color: white;` 를 추가해서 기본 배경색을 흰색으로 적용했습니다.

### Font
- `title-text` : 제목 (모바일 24px / 그외 32px + bold(700))
- `subtitle-text` : 소제목 (모바일 20px / 그외 24px + bold(700))
- `body-text` : 본문 (모바일 14px / 그외 16px)
- `caption-text` : 캡션 (모바일 12px / 그외 14px)

### Button
- `BUTTON_SIZE` 에서 round, font-size, font-weight 속성 제거 후, `round-xl`을 기본으로 수정했습니다.
  - 라운드 수정하실분들은 round-2xl 사용하시면 될 것 같구, 폰트 크기, 굵기도 사용처에서 적어주셔야합니다!
- BUTTON_SIZE에 `none` 속성을 추가했습니다! `w-fit h-fit p-0`로 적용해뒀고 UI리팩토링 할 때 적용하시기 편하실 것 같아서 추가했습니다..!

## ✅ 체크리스트

- [x] PR 하기 전에 이슈에서 빼먹은건 없는지 확인했습니다
  - [x] 라벨 및 마일스톤을 사이드 탭에서 등록했습니다.
- [x] PR을 보내는 브랜치가 올바른지 확인했습니다.
- [x] 팀원들이 리뷰하기 쉽도록 설명을 자세하게 작성했습니다.
- [x] 변경사항을 충분히 테스트 했습니다.
- [x] (함수를 구현 했을 때) JSDoc을 양식에 맞춰서 작성했습니다.
- [x] 컨벤션에 맞게 구현했습니다.

## 📷 UI 변경 사항 (선택)
<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->

<img width="508" height="185" alt="image" src="https://github.com/user-attachments/assets/f5c12732-12a2-444e-9a1b-f0e822c0e47e" />

> 아쉽게도 테일윈드 인텔리센스에는 값이 보이지않는 것 같아서 주석으로 보시기 편하게 추가해뒀습니다!

## ❓무슨 문제가 발생했나요? (선택)

- 문제는 아니고 버튼 📌 작업 내용 확인해 주시고 추가/수정 하고싶은 속성 있으면 얘기해주세요!

## 💬 기타 참고 사항 (선택)
<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->

- 버튼쪽 수정을 했기 때문에 작업하시기 전에 꼭!!!!! 
```bash
pnpm build-ui
```
적용해주셔야합니다!!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * 기본 텍스트 색상과 배경색이 업데이트되었습니다.
  * 제목, 부제목, 본문, 캡션용 새로운 타이포그래피 유틸리티 클래스가 추가되어 다양한 기기에서 일관된 텍스트 스타일을 제공합니다.
  * 버튼의 테두리 반경, 폰트 크기, 폰트 두께 스타일이 정리되었고, 새로운 "none" 사이즈 옵션이 추가되었습니다.
  * 비활성화된 버튼에서 커서 스타일이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->