### PR TITLE
z-index 정리

### DIFF
--- a/apps/what-today/src/components/Header.tsx
+++ b/apps/what-today/src/components/Header.tsx
@@ -19,7 +19,7 @@ export default function Header() {
   };
 
   return (
-    <div className='relative z-50 flex w-full justify-between py-16'>
+    <div className='relative z-40 flex w-full justify-between py-16'>
       <Link className='flex items-center gap-8' to='/'>
         <ImageLogo className='size-24' />
         <TextLogo className='hidden h-fit w-65 sm:block' />

--- a/apps/what-today/src/components/reservations-status/ReservationCalendar.tsx
+++ b/apps/what-today/src/components/reservations-status/ReservationCalendar.tsx
@@ -131,7 +131,7 @@ export default function ReservationCalendar({
         onOpenChange={setIsReservationSheetOpen}
       >
         <Popover.Content
-          className='z-50 rounded-2xl border border-gray-50 bg-white px-24 py-30'
+          className='rounded-2xl border border-gray-50 bg-white px-24 py-30'
           style={reservationPopupPosition}
         >
           <div className='h-460 w-292'>

--- a/apps/what-today/src/components/reservations-status/ReservationSheet.tsx
+++ b/apps/what-today/src/components/reservations-status/ReservationSheet.tsx
@@ -166,7 +166,7 @@ export default function ReservationSheet({ activityId, selectedDate }: Reservati
             <Select.Trigger className='h-54'>
               <Select.Value placeholder='예약 시간 선택하기' />
             </Select.Trigger>
-            <Select.Content className='z-1000'>
+            <Select.Content className='z-50'>
               <Select.Group>
                 <Select.Label>시간대별 예약</Select.Label>
                 {state.dailySchedule.map(({ scheduleId, startTime, endTime }) => {

--- a/apps/what-today/src/layouts/Mypage.tsx
+++ b/apps/what-today/src/layouts/Mypage.tsx
@@ -42,7 +42,7 @@ export default function MyPageLayout() {
         onLogoutClick={handleLogout}
       />
       <Button
-        className={twMerge('fixed top-68 left-4 z-60 w-fit p-0 md:hidden', isSidebarOpen && 'hidden')}
+        className={twMerge('fixed top-68 left-4 z-55 w-fit p-0 md:hidden', isSidebarOpen && 'hidden')}
         size='xs'
         variant='none'
         onClick={() => setSidebarOpen(true)}

--- a/apps/what-today/src/pages/main/index.tsx
+++ b/apps/what-today/src/pages/main/index.tsx
@@ -80,101 +80,104 @@ export default function MainPage() {
   const pagedItems = sortedItems.slice((currentPage - 1) * itemsPerPage, currentPage * itemsPerPage);
 
   return (
-    <div className='relative z-10 mt-40 flex h-auto flex-col gap-60'>
-      <MainBanner />
+    <>
+      <div className='to-primary-500/40 absolute top-0 left-0 h-1/2 w-full bg-gradient-to-t from-transparent' />
+      <div className='relative z-10 mt-40 flex h-auto flex-col gap-60'>
+        <MainBanner />
 
-      <div className='flex flex-col gap-20'>
-        <h2 className='title-text'>🔥 인기 체험</h2>
-        <div className='-mx-15 flex'>
-          <Carousel items={activities} itemsPerPage={itemsPerPage} onClick={(id) => navigate(`/activities/${id}`)} />
-        </div>
-      </div>
-
-      <div className='flex flex-col gap-20 md:px-30'>
-        <h2 className='title-text flex justify-center'>무엇을 체험하고 싶으신가요?</h2>
-        <MainSearchInput onClick={handleSearch} />
-      </div>
-
-      <div className='flex flex-col gap-20'>
-        <h2 className='title-text flex items-center gap-12'>🛼 모든 체험</h2>
-
-        <div className='flex flex-wrap items-center justify-between gap-20'>
-          <RadioGroup
-            radioGroupClassName='flex flex-wrap gap-12 min-w-0 max-w-full'
-            selectedValue={selectedCategory}
-            onSelect={setSelectedCategory}
-          >
-            <div className='flex max-w-full min-w-0 flex-wrap gap-12'>
-              <RadioGroup.Radio className='flex gap-8' value='문화 · 예술'>
-                <ArtIcon />
-                문화 예술
-              </RadioGroup.Radio>
-              <RadioGroup.Radio value='음식'>
-                <FoodIcon />
-                음식
-              </RadioGroup.Radio>
-              <RadioGroup.Radio value='스포츠'>
-                <SportIcon />
-                스포츠
-              </RadioGroup.Radio>
-              <RadioGroup.Radio value='웰빙'>
-                <WellbeingIcon />
-                웰빙
-              </RadioGroup.Radio>
-              <RadioGroup.Radio value='버스'>
-                <BusIcon />
-                버스
-              </RadioGroup.Radio>
-              <RadioGroup.Radio value='투어'>
-                <TourIcon />
-                여행
-              </RadioGroup.Radio>
-            </div>
-          </RadioGroup>
-
-          <div className='shrink-0'>
-            <Select.Root
-              value={selectedValue}
-              onChangeValue={(item) => {
-                setSelectedValue(item);
-                if (item) {
-                  setSortOrder(item.value as 'asc' | 'desc');
-                }
-              }}
-            >
-              <Select.Trigger className='text-2lg flex min-w-fit gap-8 border-none bg-white px-15 py-10'>
-                <Select.Value className='text-gray-950' placeholder='가격' />
-              </Select.Trigger>
-              <Select.Content>
-                <Select.Group className='body-text text-center whitespace-nowrap'>
-                  <Select.Item value='desc'> 높은순</Select.Item>
-                  <Select.Item value='asc'> 낮은순</Select.Item>
-                </Select.Group>
-              </Select.Content>
-            </Select.Root>
+        <div className='flex flex-col gap-20'>
+          <h2 className='title-text'>🔥 인기 체험</h2>
+          <div className='-mx-15 flex'>
+            <Carousel items={activities} itemsPerPage={itemsPerPage} onClick={(id) => navigate(`/activities/${id}`)} />
           </div>
         </div>
 
-        <div className='grid grid-cols-2 gap-12 md:grid-cols-2 lg:grid-cols-4'>
-          {pagedItems.map((item) => (
-            <MainCard.Root
-              key={item.id}
-              bannerImageUrl={item.bannerImageUrl}
-              className=''
-              price={item.price}
-              rating={item.rating}
-              reviewCount={item.reviewCount}
-              title={item.title}
-              onClick={() => navigate(`/activities/${item.id}`)}
-            >
-              <MainCard.Image className='' />
-              <MainCard.Content />
-            </MainCard.Root>
-          ))}
+        <div className='flex flex-col gap-20 md:px-30'>
+          <h2 className='title-text flex justify-center'>무엇을 체험하고 싶으신가요?</h2>
+          <MainSearchInput onClick={handleSearch} />
         </div>
 
-        <Pagination currentPage={currentPage} totalPages={totalPages} onPageChange={setCurrentPage} />
+        <div className='flex flex-col gap-20'>
+          <h2 className='title-text flex items-center gap-12'>🛼 모든 체험</h2>
+
+          <div className='flex flex-wrap items-center justify-between gap-20'>
+            <RadioGroup
+              radioGroupClassName='flex flex-wrap gap-12 min-w-0 max-w-full'
+              selectedValue={selectedCategory}
+              onSelect={setSelectedCategory}
+            >
+              <div className='flex max-w-full min-w-0 flex-wrap gap-12'>
+                <RadioGroup.Radio className='flex gap-8' value='문화 · 예술'>
+                  <ArtIcon />
+                  문화 예술
+                </RadioGroup.Radio>
+                <RadioGroup.Radio value='음식'>
+                  <FoodIcon />
+                  음식
+                </RadioGroup.Radio>
+                <RadioGroup.Radio value='스포츠'>
+                  <SportIcon />
+                  스포츠
+                </RadioGroup.Radio>
+                <RadioGroup.Radio value='웰빙'>
+                  <WellbeingIcon />
+                  웰빙
+                </RadioGroup.Radio>
+                <RadioGroup.Radio value='버스'>
+                  <BusIcon />
+                  버스
+                </RadioGroup.Radio>
+                <RadioGroup.Radio value='투어'>
+                  <TourIcon />
+                  여행
+                </RadioGroup.Radio>
+              </div>
+            </RadioGroup>
+
+            <div className='shrink-0'>
+              <Select.Root
+                value={selectedValue}
+                onChangeValue={(item) => {
+                  setSelectedValue(item);
+                  if (item) {
+                    setSortOrder(item.value as 'asc' | 'desc');
+                  }
+                }}
+              >
+                <Select.Trigger className='text-2lg flex min-w-fit gap-8 border-none bg-white px-15 py-10'>
+                  <Select.Value className='text-gray-950' placeholder='가격' />
+                </Select.Trigger>
+                <Select.Content>
+                  <Select.Group className='body-text text-center whitespace-nowrap'>
+                    <Select.Item value='desc'> 높은순</Select.Item>
+                    <Select.Item value='asc'> 낮은순</Select.Item>
+                  </Select.Group>
+                </Select.Content>
+              </Select.Root>
+            </div>
+          </div>
+
+          <div className='grid grid-cols-2 gap-12 md:grid-cols-2 lg:grid-cols-4'>
+            {pagedItems.map((item) => (
+              <MainCard.Root
+                key={item.id}
+                bannerImageUrl={item.bannerImageUrl}
+                className=''
+                price={item.price}
+                rating={item.rating}
+                reviewCount={item.reviewCount}
+                title={item.title}
+                onClick={() => navigate(`/activities/${item.id}`)}
+              >
+                <MainCard.Image className='' />
+                <MainCard.Content />
+              </MainCard.Root>
+            ))}
+          </div>
+
+          <Pagination currentPage={currentPage} totalPages={totalPages} onPageChange={setCurrentPage} />
+        </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/packages/design-system/src/components/ProfileImageInput.tsx
+++ b/packages/design-system/src/components/ProfileImageInput.tsx
@@ -136,7 +136,7 @@ export default function ProfileImageInput({ src, initial = src, onChange }: Prof
     <div className='flex flex-col items-center gap-16'>
       <label className='relative rounded-full border border-gray-50 p-8'>
         {shouldShowDeleteButton && (
-          <div className='absolute top-16 right-8 z-10'>
+          <div className='absolute top-16 right-8 z-3'>
             <DeleteButton onDelete={handleDelete} />
           </div>
         )}

--- a/packages/design-system/src/components/ReservationCard.tsx
+++ b/packages/design-system/src/components/ReservationCard.tsx
@@ -88,7 +88,7 @@ export default function ReservationCard({
       className='flex h-150 cursor-pointer items-stretch -space-x-38 rounded-2xl border border-gray-50 md:h-160 md:-space-x-20 xl:-space-x-26'
       onClick={onClick}
     >
-      <section className='z-10 flex w-full flex-col justify-between rounded-l-2xl rounded-r-3xl bg-white p-20 xl:gap-6'>
+      <section className='z-5 flex w-full flex-col justify-between rounded-l-2xl rounded-r-3xl bg-white p-20 xl:gap-6'>
         <div className='flex flex-col gap-4 xl:gap-6'>
           {/* badge 컴포넌트로 수정 예정 */}
           <span className={`caption-text w-fit rounded-full px-8 py-2 text-center font-bold ${style}`}>{badge}</span>

--- a/packages/design-system/src/components/Toast/index.tsx
+++ b/packages/design-system/src/components/Toast/index.tsx
@@ -57,7 +57,7 @@ export const useToast = () => {
             <motion.div
               animate={{ opacity: 1, y: 0 }}
               className={twMerge(
-                'fixed top-28 left-1/2 z-50 flex w-320 -translate-x-1/2 items-center gap-12 rounded-lg p-10 text-white shadow',
+                'fixed top-28 left-1/2 z-80 flex w-320 -translate-x-1/2 items-center gap-12 rounded-lg p-10 text-white shadow',
                 statusStyle.className,
               )}
               exit={{ opacity: 0, y: -20 }}

--- a/packages/design-system/src/components/bottomsheet/BottomSheetOverlay.tsx
+++ b/packages/design-system/src/components/bottomsheet/BottomSheetOverlay.tsx
@@ -8,6 +8,6 @@ import type { BottomSheetOverlayProps } from './types';
  */
 export function BottomSheetOverlay({ onClick, className }: BottomSheetOverlayProps) {
   return (
-    <div className={twMerge('fixed inset-0 z-40 bg-black/5 backdrop-brightness-50', className)} onClick={onClick} />
+    <div className={twMerge('fixed inset-0 z-60 bg-black/5 backdrop-brightness-50', className)} onClick={onClick} />
   );
 }

--- a/packages/design-system/src/components/bottomsheet/BottomSheetRoot.tsx
+++ b/packages/design-system/src/components/bottomsheet/BottomSheetRoot.tsx
@@ -38,7 +38,7 @@ export function BottomSheetRoot({ isOpen, onClose, children, className }: Bottom
         <div
           ref={sheetRef}
           className={twMerge(
-            'fixed right-0 bottom-0 left-0 z-50 flex flex-col rounded-t-2xl bg-white',
+            'fixed right-0 bottom-0 left-0 z-65 flex flex-col rounded-t-2xl bg-white',
             'transition-transform duration-300 ease-out',
             isOpen ? 'translate-y-0' : 'translate-y-full',
             className,

--- a/packages/design-system/src/components/modal/ModalContent.tsx
+++ b/packages/design-system/src/components/modal/ModalContent.tsx
@@ -42,10 +42,10 @@ function ModalContent({ children, className }: ModalContentProps) {
   return (
     <Portal>
       {/* 오버레이 */}
-      <div className='fixed inset-0 z-40 bg-black/30' />
+      <div className='fixed inset-0 z-65 bg-black/30' />
 
       {/* 모달 컨텐츠 */}
-      <div className='fixed inset-0 z-50 flex items-center justify-center'>
+      <div className='fixed inset-0 z-70 flex items-center justify-center'>
         <div
           ref={modalRef}
           aria-modal='true'

--- a/packages/design-system/src/components/popover/PopoverContent.tsx
+++ b/packages/design-system/src/components/popover/PopoverContent.tsx
@@ -60,10 +60,10 @@ function PopoverContent({
 
   return (
     <Portal>
-      {overlay && <div className='fixed inset-0 z-99 bg-black/30' />}
+      {overlay && <div className='fixed inset-0 z-60 bg-black/30' />}
       <div
         ref={handleContentRef}
-        className={twMerge('absolute top-0 left-0 z-50', className)}
+        className={twMerge('absolute top-0 left-0 z-65', className)}
         style={{
           position: direction.startsWith('fixed-') ? 'fixed' : 'absolute', // Trigger의 위치에 따르지 않고, 뷰포트가 기준인 경우에는 fixed로 고정 (ex. Modal은 화면 정중앙에)
           top: `${contentCoords.top}px`,


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- #187

## 📌 작업 내용
<!-- 해당 PR의 변경 사항을 자세하게 적어주세요.-->

- z-index가 충돌나는 스타일 오류를 해결했습니다. (대략적으로 나눈 계층은 아래와 같습니다.)
  - 페이지 내부에서 쓰이는 z-index는 0~10 사이
  - 사이드바, 모달, 팝오버 등에서는 50~70 사이
  - 토스트 메시지 80

## ✅ 체크리스트

- [x] PR 하기 전에 이슈에서 빼먹은건 없는지 확인했습니다
  - [x] 라벨 및 마일스톤을 사이드 탭에서 등록했습니다.
- [x] PR을 보내는 브랜치가 올바른지 확인했습니다.
- [x] 팀원들이 리뷰하기 쉽도록 설명을 자세하게 작성했습니다.
- [x] 변경사항을 충분히 테스트 했습니다.
- [x] (함수를 구현 했을 때) JSDoc을 양식에 맞춰서 작성했습니다.
- [x] 컨벤션에 맞게 구현했습니다.

## 📷 UI 변경 사항 (선택)
<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->

- 

## ❓무슨 문제가 발생했나요? (선택)

-

## 💬 기타 참고 사항 (선택)
<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->

-
