### PR TITLE
메인페이지 QA반영

### DIFF
--- a/apps/what-today/src/pages/main/index.tsx
+++ b/apps/what-today/src/pages/main/index.tsx
@@ -85,7 +85,7 @@ export default function MainPage() {
     <div className='relative z-10 mt-40 flex h-auto flex-col gap-60'>
       <MainBanner />
       <div className='flex flex-col gap-20'>
-        <h2 className='subtitle-text md:title-text'>🔥 인기 체험</h2>
+        <h2 className='title-text'>🔥 인기 체험</h2>
         <div className='-mx-15 flex'>
           <Carousel
             items={popularActivities}
@@ -96,14 +96,14 @@ export default function MainPage() {
       </div>
 
       <div className='flex flex-col gap-20'>
-        <h2 className='subtitle-text md:title-text flex justify-center'>무엇을 체험하고 싶으신가요?</h2>
+        <h2 className='title-text flex justify-center'>무엇을 체험하고 싶으신가요?</h2>
         <MainSearchInput onClick={handleSearch} />
       </div>
 
       <div className='flex flex-col gap-20'>
         {/* 제목 + 가격 드롭다운 */}
         <div className='flex flex-wrap items-center justify-between gap-12'>
-          <h2 className='subtitle-text md:title-text flex items-center gap-12 text-gray-950'>🛼 모든 체험</h2>
+          <h2 className='title-text flex items-center gap-12 text-gray-950'>🛼 모든 체험</h2>
 
           <Select.Root
             value={selectedValue}

--- a/apps/what-today/src/pages/main/index.tsx
+++ b/apps/what-today/src/pages/main/index.tsx
@@ -8,6 +8,7 @@ import {
   MainBanner,
   MainCard,
   MainSearchInput,
+  NoResult,
   Pagination,
   RadioGroup,
   Select,
@@ -30,7 +31,7 @@ export default function MainPage() {
   const [selectedCategory, setSelectedCategory] = useState<string | number>('');
   const navigate = useNavigate();
 
-  //  반응형 카드 수 조정
+  // 반응형 카드 수 조정
   useEffect(() => {
     const handleResize = () => {
       const width = window.innerWidth;
@@ -38,7 +39,6 @@ export default function MainPage() {
       else if (width < 1024) setItemsPerPage(4);
       else setItemsPerPage(8);
     };
-
     handleResize();
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
@@ -51,7 +51,9 @@ export default function MainPage() {
     staleTime: 1000 * 60 * 5, // 5분 캐싱
   });
 
-  //  activities가 바뀔 때 초기 상태 설정
+  const popularActivities = [...activities].sort((a, b) => b.reviewCount - a.reviewCount).slice(0, 12);
+
+  // activities가 바뀔 때 초기 상태 설정
   useEffect(() => {
     if (activities.length > 0) {
       setSearchResult(activities);
@@ -67,7 +69,7 @@ export default function MainPage() {
     setSelectedValue(null);
   };
 
-  //  정렬 변경 시 페이지 초기화
+  // 정렬 변경 시 페이지 초기화
   useEffect(() => {
     setCurrentPage(1);
   }, [sortOrder]);
@@ -80,97 +82,106 @@ export default function MainPage() {
   const pagedItems = sortedItems.slice((currentPage - 1) * itemsPerPage, currentPage * itemsPerPage);
 
   return (
-    <div className='relative z-10 mt-40 flex h-auto flex-col gap-60'>
+    <div className='relative z-10 mt-40 flex h-auto flex-col gap-60 overflow-x-hidden'>
       <MainBanner />
-
       <div className='flex flex-col gap-20'>
-        <h2 className='title-text'>🔥 인기 체험</h2>
+        <h2 className='subtitle-text md:title-text'>🔥 인기 체험</h2>
         <div className='-mx-15 flex'>
-          <Carousel items={activities} itemsPerPage={itemsPerPage} onClick={(id) => navigate(`/activities/${id}`)} />
+          <Carousel
+            items={popularActivities}
+            itemsPerPage={itemsPerPage}
+            onClick={(id) => navigate(`/activities/${id}`)}
+          />
         </div>
       </div>
 
-      <div className='flex flex-col gap-20 md:px-30'>
-        <h2 className='title-text flex justify-center'>무엇을 체험하고 싶으신가요?</h2>
+      <div className='flex flex-col gap-20'>
+        <h2 className='subtitle-text md:title-text flex justify-center'>무엇을 체험하고 싶으신가요?</h2>
         <MainSearchInput onClick={handleSearch} />
       </div>
 
       <div className='flex flex-col gap-20'>
-        <h2 className='title-text flex items-center gap-12'>🛼 모든 체험</h2>
+        {/* 제목 + 가격 드롭다운 */}
+        <div className='flex flex-wrap items-center justify-between gap-12'>
+          <h2 className='subtitle-text md:title-text flex items-center gap-12 text-gray-950'>🛼 모든 체험</h2>
 
-        <div className='flex flex-wrap items-center justify-between gap-20'>
+          <Select.Root
+            value={selectedValue}
+            onChangeValue={(item) => {
+              setSelectedValue(item);
+              if (item) {
+                setSortOrder(item.value as 'asc' | 'desc');
+              }
+            }}
+          >
+            <Select.Trigger className='text-2lg flex min-w-fit gap-6 border-none bg-white px-15 py-10'>
+              <Select.Value className='text-gray-950' placeholder='가격' />
+            </Select.Trigger>
+            <Select.Content>
+              <Select.Group className='body-text text-center whitespace-nowrap'>
+                <Select.Item value='desc'> 높은순</Select.Item>
+                <Select.Item value='asc'> 낮은순</Select.Item>
+              </Select.Group>
+            </Select.Content>
+          </Select.Root>
+        </div>
+
+        {/* 라디오 버튼 가로 스크롤 */}
+        <div className='overflow-x-hidden'>
           <RadioGroup
-            radioGroupClassName='flex flex-wrap gap-12 min-w-0 max-w-full'
+            radioGroupClassName='items-center min-w-0 max-w-full overflow-x-auto no-scrollbar'
             selectedValue={selectedCategory}
             onSelect={setSelectedCategory}
           >
-            <div className='flex max-w-full min-w-0 flex-wrap gap-12'>
-              <RadioGroup.Radio className='flex gap-8' value='문화 · 예술'>
-                <ArtIcon />
-                문화 예술
-              </RadioGroup.Radio>
-              <RadioGroup.Radio value='음식'>
-                <FoodIcon />
-                음식
-              </RadioGroup.Radio>
-              <RadioGroup.Radio value='스포츠'>
-                <SportIcon />
-                스포츠
-              </RadioGroup.Radio>
-              <RadioGroup.Radio value='웰빙'>
-                <WellbeingIcon />
-                웰빙
-              </RadioGroup.Radio>
-              <RadioGroup.Radio value='버스'>
-                <BusIcon />
-                버스
-              </RadioGroup.Radio>
-              <RadioGroup.Radio value='투어'>
-                <TourIcon />
-                여행
-              </RadioGroup.Radio>
-            </div>
+            <RadioGroup.Radio className='flex gap-8' value='문화 · 예술'>
+              <ArtIcon className='size-15' />
+              문화 예술
+            </RadioGroup.Radio>
+            <RadioGroup.Radio value='음식'>
+              <FoodIcon className='size-15' />
+              음식
+            </RadioGroup.Radio>
+            <RadioGroup.Radio value='스포츠'>
+              <SportIcon className='size-15' />
+              스포츠
+            </RadioGroup.Radio>
+            <RadioGroup.Radio value='웰빙'>
+              <WellbeingIcon className='size-15' />
+              웰빙
+            </RadioGroup.Radio>
+            <RadioGroup.Radio value='버스'>
+              <BusIcon className='size-15' />
+              버스
+            </RadioGroup.Radio>
+            <RadioGroup.Radio value='투어'>
+              <TourIcon className='size-15' />
+              여행
+            </RadioGroup.Radio>
           </RadioGroup>
-
-          <div className='shrink-0'>
-            <Select.Root
-              value={selectedValue}
-              onChangeValue={(item) => {
-                setSelectedValue(item);
-                if (item) {
-                  setSortOrder(item.value as 'asc' | 'desc');
-                }
-              }}
-            >
-              <Select.Trigger className='text-2lg flex min-w-fit gap-8 border-none bg-white px-15 py-10'>
-                <Select.Value className='text-gray-950' placeholder='가격' />
-              </Select.Trigger>
-              <Select.Content>
-                <Select.Group className='body-text text-center whitespace-nowrap'>
-                  <Select.Item value='desc'> 높은순</Select.Item>
-                  <Select.Item value='asc'> 낮은순</Select.Item>
-                </Select.Group>
-              </Select.Content>
-            </Select.Root>
-          </div>
         </div>
 
+        {/* 카드 리스트 */}
         <div className='grid grid-cols-2 gap-12 md:grid-cols-2 lg:grid-cols-4'>
-          {pagedItems.map((item) => (
-            <MainCard.Root
-              key={item.id}
-              bannerImageUrl={item.bannerImageUrl}
-              className=''
-              price={item.price}
-              rating={item.rating}
-              reviewCount={item.reviewCount}
-              title={item.title}
-              onClick={() => navigate(`/activities/${item.id}`)}
-            >
-              <MainCard.Image className='' />
-              <MainCard.Content />
-            </MainCard.Root>
-          ))}
+          {filteredItems.length === 0 ? (
+            <div className='col-span-full flex justify-center py-40'>
+              <NoResult />
+            </div>
+          ) : (
+            pagedItems.map((item) => (
+              <MainCard.Root
+                key={item.id}
+                bannerImageUrl={item.bannerImageUrl}
+                price={item.price}
+                rating={item.rating}
+                reviewCount={item.reviewCount}
+                title={item.title}
+                onClick={() => navigate(`/activities/${item.id}`)}
+              >
+                <MainCard.Image />
+                <MainCard.Content />
+              </MainCard.Root>
+            ))
+          )}
         </div>
 
         <Pagination currentPage={currentPage} totalPages={totalPages} onPageChange={setCurrentPage} />

--- a/apps/what-today/src/pages/main/index.tsx
+++ b/apps/what-today/src/pages/main/index.tsx
@@ -103,7 +103,7 @@ export default function MainPage() {
       <div className='flex flex-col gap-20'>
         {/* 제목 + 가격 드롭다운 */}
         <div className='flex flex-wrap items-center justify-between gap-12'>
-          <h2 className='title-text flex items-center gap-12 text-gray-950'>🛼 모든 체험</h2>
+          <h2 className='title-text flex items-center gap-12'>🛼 모든 체험</h2>
 
           <Select.Root
             value={selectedValue}

--- a/apps/what-today/src/pages/main/index.tsx
+++ b/apps/what-today/src/pages/main/index.tsx
@@ -82,7 +82,7 @@ export default function MainPage() {
   const pagedItems = sortedItems.slice((currentPage - 1) * itemsPerPage, currentPage * itemsPerPage);
 
   return (
-    <div className='relative z-10 mt-40 flex h-auto flex-col gap-60 overflow-x-hidden'>
+    <div className='relative z-10 mt-40 flex h-auto flex-col gap-60'>
       <MainBanner />
       <div className='flex flex-col gap-20'>
         <h2 className='subtitle-text md:title-text'>🔥 인기 체험</h2>

--- a/apps/what-today/src/pages/main/index.tsx
+++ b/apps/what-today/src/pages/main/index.tsx
@@ -184,7 +184,9 @@ export default function MainPage() {
           )}
         </div>
 
-        <Pagination currentPage={currentPage} totalPages={totalPages} onPageChange={setCurrentPage} />
+        {filteredItems.length > 0 && (
+          <Pagination currentPage={currentPage} totalPages={totalPages} onPageChange={setCurrentPage} />
+        )}
       </div>
     </div>
   );

--- a/packages/design-system/src/components/Footer.tsx
+++ b/packages/design-system/src/components/Footer.tsx
@@ -4,16 +4,13 @@ import { TextLogo } from './logos';
 export default function Footer() {
   return (
     <footer className='mt-80 w-full border-t border-gray-100 bg-white py-24'>
-      <div className='mx-auto grid w-full max-w-7xl grid-cols-1 items-center gap-16 px-[5vw] text-center md:grid-cols-2 md:text-left'>
+      <div className='mx-auto grid w-full max-w-7xl grid-cols-1 items-stretch gap-16 px-[5vw] text-center md:grid-cols-2 md:text-left'>
         {/* 🔹 왼쪽: 비전 메시지 + 로고 */}
         <div className='flex flex-col items-center gap-4 md:items-start'>
-          <a
-            className='flex items-center gap-2 transition hover:scale-105'
-            href='https://what-today-design-system.vercel.app/docs'
-          >
+          <div className='flex items-center gap-2 transition hover:scale-105'>
             <ImageLogo className='size-36' />
             <TextLogo className='size-80 text-sky-500' />
-          </a>
+          </div>
           <h2 className='text-lg font-bold text-gray-700 md:text-xl'>오늘뭐해는</h2>
           <p className='text-md leading-relaxed text-gray-500 md:text-lg'>
             무의미한 일상 속에서 <br className='sm:hidden' />
@@ -22,7 +19,7 @@ export default function Footer() {
         </div>
 
         {/* 🔹 오른쪽: GitHub + 날짜 (데스크탑 전용) */}
-        <div className='flex flex-col items-center justify-center gap-4 md:mt-40 md:items-end'>
+        <div className='flex h-full flex-col items-center justify-end gap-4 md:items-end'>
           <p className='text-lg text-gray-400 md:text-xl'>© 2025.07</p>
           <a
             aria-label='GitHub'

--- a/packages/design-system/src/components/Footer.tsx
+++ b/packages/design-system/src/components/Footer.tsx
@@ -7,7 +7,10 @@ export default function Footer() {
       <div className='mx-auto grid w-full max-w-7xl grid-cols-1 items-center gap-16 px-[5vw] text-center md:grid-cols-2 md:text-left'>
         {/* 🔹 왼쪽: 비전 메시지 + 로고 */}
         <div className='flex flex-col items-center gap-4 md:items-start'>
-          <a className='flex items-center gap-2 transition hover:scale-105' href='/'>
+          <a
+            className='flex items-center gap-2 transition hover:scale-105'
+            href='https://what-today-design-system.vercel.app/docs'
+          >
             <ImageLogo className='size-36' />
             <TextLogo className='size-80 text-sky-500' />
           </a>

--- a/packages/design-system/src/components/MainSearchInput/MainSearchInput.tsx
+++ b/packages/design-system/src/components/MainSearchInput/MainSearchInput.tsx
@@ -26,7 +26,7 @@ export default function MainSearchInput({ onClick }: MainSearchInputProps) {
 
   return (
     <div className='relative flex w-full items-center justify-between bg-white'>
-      <div className='absolute inset-y-0 left-0 flex items-center pl-20 md:pl-28'>
+      <div className='absolute inset-y-0 left-0 flex items-center pl-20 md:pl-32'>
         <SearchIcon className='cursor-pointer text-gray-400' onClick={handleFocusInput} />
       </div>
       <input

--- a/packages/design-system/src/components/RadioGroup/RadioGroup.tsx
+++ b/packages/design-system/src/components/RadioGroup/RadioGroup.tsx
@@ -1,3 +1,4 @@
+import { motion } from 'motion/react';
 import { createContext, useContext } from 'react';
 import { cloneElement, isValidElement, type ReactElement } from 'react';
 import React from 'react';
@@ -97,7 +98,19 @@ export default function RadioGroup({
       }}
     >
       {title && <RadioGroup.Title />}
-      <div className={twMerge('flex flex-col gap-2', radioGroupClassName)}>{children}</div>
+      <motion.div
+        animate={{ x: 0, opacity: 1 }}
+        className={twMerge('no-scrollbar flex flex-nowrap gap-4 overflow-x-auto scroll-smooth', radioGroupClassName)}
+        initial={{ x: -20, opacity: 0 }}
+        style={{
+          scrollbarWidth: 'none',
+          msOverflowStyle: 'none',
+          scrollPaddingLeft: '1rem', // 첫 아이템 여백
+        }}
+        transition={{ duration: 0.4 }}
+      >
+        {children}
+      </motion.div>
     </RadioContext.Provider>
   );
 }
@@ -143,7 +156,7 @@ RadioGroup.Radio = function Radio({ value, children, className = '', name = 'rad
   };
 
   const BASE_STYLE =
-    'flex gap-8 text-md md:text-lg  cursor-pointer items-center rounded-full border  px-12 py-6 md:px-18 md:py-9 font-bold whitespace-nowrap transition-all duration-300 ease-in-out';
+    'flex gap-8 text-sm md:text-md cursor-pointer items-center rounded-full border px-10 py-6 md:px-14 md:py-6 font-bold whitespace-nowrap transition-all duration-300 ease-in-out';
   const SELECTED_STYLE = 'bg-black text-white hover:scale-110 active:scale-95';
   const UNSELECTED_STYLE = 'border-gray-300 bg-white text-gray-700 hover:bg-gray-100';
 

--- a/packages/design-system/src/components/RadioGroup/RadioGroup.tsx
+++ b/packages/design-system/src/components/RadioGroup/RadioGroup.tsx
@@ -156,7 +156,7 @@ RadioGroup.Radio = function Radio({ value, children, className = '', name = 'rad
   };
 
   const BASE_STYLE =
-    'flex gap-8 text-sm md:text-md cursor-pointer items-center rounded-full border px-10 py-6 md:px-14 md:py-6 font-bold whitespace-nowrap transition-all duration-300 ease-in-out';
+    'flex gap-8 caption-text cursor-pointer items-center rounded-full border px-10 py-6 md:px-14 md:py-6 font-bold whitespace-nowrap transition-all duration-300 ease-in-out';
   const SELECTED_STYLE = 'bg-black text-white hover:scale-110 active:scale-95';
   const UNSELECTED_STYLE = 'border-gray-300 bg-white text-gray-700 hover:bg-gray-100';
 


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- #188

## 📌 작업 내용
<!-- 해당 PR의 변경 사항을 자세하게 적어주세요.-->

- 인기체험 필터링 댓굴 후기 개수 순으로 정렬
- 슬라이더 12개로 끊기 
` const popularActivities = [...activities].sort((a, b) => b.reviewCount - a.reviewCount).slice(0, 12);`

- 검색창 양옆 패딩 제거
- 모든체험 라디로 필터링 했을때 아무것도 없을 경우 No Result 추가
- 페이지네이션 끝 페이지에서 > 다음페이지 bg 제거
- Footer에서 오늘뭐해 로고 누를 시 디자인 시스템으로 이동
- 모바일일때 라디오때문에 왼쪽으로 밀리는 현상해결
 ```
 <a
            className='flex items-center gap-2 transition hover:scale-105'
            href='https://what-today-design-system.vercel.app/docs'
          >
            <ImageLogo className='size-36' />
            <TextLogo className='size-80 text-sky-500' />
          </a>

```
## ✅ 체크리스트

- [x] PR 하기 전에 이슈에서 빼먹은건 없는지 확인했습니다
  - [x] 라벨 및 마일스톤을 사이드 탭에서 등록했습니다.
- [x] PR을 보내는 브랜치가 올바른지 확인했습니다.
- [x] 팀원들이 리뷰하기 쉽도록 설명을 자세하게 작성했습니다.
- [x] 변경사항을 충분히 테스트 했습니다.
- [x] (함수를 구현 했을 때) JSDoc을 양식에 맞춰서 작성했습니다.
- [x] 컨벤션에 맞게 구현했습니다.

## 📷 UI 변경 사항 (선택)
<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->

-검색창 양옆 패딩제거 인기체험 댓글 후기순, 슬라이드 12개
<img width="702" height="435" alt="스크린샷 2025-08-01 오후 1 10 41" src="https://github.com/user-attachments/assets/e65bbae5-291a-421d-b79b-cd7f3d13269a" />

-페이지네이션 끝 페이지에서 bg제거

<img width="652" height="301" alt="스크린샷 2025-07-31 오후 1 48 31" src="https://github.com/user-attachments/assets/ea54c74b-98b7-457a-a0cd-4d300e324dc8" />


-라디오 필터링 했을때 아무체험도 없을시 NIo Result추가
<img width="882" height="343" alt="스크린샷 2025-08-01 오후 1 28 20" src="https://github.com/user-attachments/assets/8bb7938f-fc9e-41c5-91b3-c59caabb9325" />



## ❓무슨 문제가 발생했나요? (선택)

-

## 💬 기타 참고 사항 (선택)
<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 검색 결과가 없을 때 전용 안내 컴포넌트가 표시됩니다.
  * 인기 체험이 리뷰 수 기준 상위 12개로 엄선되어 보여집니다.

* **UI/UX 개선**
  * 가격 정렬 드롭다운이 카테고리 필터 위로 이동하고, 레이아웃 및 스타일이 개선되었습니다.
  * 카테고리 라디오 버튼 그룹이 가로 스크롤 및 애니메이션 효과를 지원합니다.
  * 라디오 버튼 크기와 간격이 조정되어 더 깔끔하게 표시됩니다.
  * 검색 입력창의 아이콘 위치가 중간 화면 이상에서 더 오른쪽으로 이동했습니다.
  * 섹션 제목 스타일이 반응형으로 개선되었습니다.
  * 푸터의 로고가 링크 제거로 비활성화되었고, 아이콘 정렬 및 위치가 조정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->