### PR TITLE
체험 상세페이지 로그인 상태 기반 조건부 기능 구현

### DIFF
--- a/apps/what-today/src/components/activities/ActivitiesInformation.tsx
+++ b/apps/what-today/src/components/activities/ActivitiesInformation.tsx
@@ -39,6 +39,11 @@ export default function ActivitiesInformation({
       deleteActivity(Number(id), {
         onSuccess: () => {
           setIsDeleteOpen(false);
+          toast({
+            title: '삭제 성공',
+            description: '체험이 성공적으로 삭제되었습니다.',
+            type: 'success',
+          });
           navigate('/');
         },
         onError: (error) => {
@@ -60,7 +65,7 @@ export default function ActivitiesInformation({
           <p className='text-md text-gray-950'>{category}</p>
           {isAuthor && (
             <Dropdown.Root>
-              <Dropdown.Trigger />
+              <Dropdown.Trigger className='flex size-24 items-center justify-center' />
               <Dropdown.Menu>
                 <Dropdown.Item onClick={() => navigate(`/experiences/create/${id}`)}>수정하기</Dropdown.Item>
                 <Dropdown.Item onClick={() => setIsDeleteOpen(true)}>삭제하기</Dropdown.Item>

--- a/apps/what-today/src/components/activities/ReservationBottomBar.tsx
+++ b/apps/what-today/src/components/activities/ReservationBottomBar.tsx
@@ -11,6 +11,7 @@ export default function ReservationBottomBar({
   onSelectDate,
   onReserve,
   isSubmitting = false,
+  isAuthor = false,
 }: ReservationBottomBarProps) {
   const totalPrice = reservation ? price * reservation.headCount : price;
   const formattedDateTime = reservation ? `${reservation.date} ${reservation.startTime} ~ ${reservation.endTime}` : '';
@@ -35,8 +36,14 @@ export default function ReservationBottomBar({
         </Button>
       </div>
 
-      <Button className='w-full' disabled={!reservation || isSubmitting} size='lg' variant='fill' onClick={onReserve}>
-        {isSubmitting ? '예약 중...' : '예약하기'}
+      <Button
+        className='w-full'
+        disabled={!reservation || isSubmitting || isAuthor}
+        size='lg'
+        variant='fill'
+        onClick={onReserve}
+      >
+        {isSubmitting ? '예약 중...' : isAuthor ? '내가 만든 체험이에요' : '예약하기'}
       </Button>
     </div>
   );

--- a/apps/what-today/src/components/activities/ReservationBottomBar.tsx
+++ b/apps/what-today/src/components/activities/ReservationBottomBar.tsx
@@ -43,7 +43,7 @@ export default function ReservationBottomBar({
         variant='fill'
         onClick={onReserve}
       >
-        {isSubmitting ? '예약 중...' : isAuthor ? '내가 만든 체험이에요' : '예약하기'}
+        {isSubmitting ? '예약 중...' : isAuthor ? '예약 불가' : '예약하기'}
       </Button>
     </div>
   );

--- a/apps/what-today/src/components/activities/ReservationBottomBar.tsx
+++ b/apps/what-today/src/components/activities/ReservationBottomBar.tsx
@@ -18,12 +18,11 @@ export default function ReservationBottomBar({
   const formattedDateTime = reservation ? `${reservation.date} ${reservation.startTime} ~ ${reservation.endTime}` : '';
 
   // 버튼 텍스트 결정
-  const getButtonText = () => {
-    if (isSubmitting) return '예약 중...';
-    if (!isLoggedIn) return '로그인 필요';
-    if (isAuthor) return '예약 불가';
-    return '예약하기';
-  };
+  let buttonText = '';
+  if (isSubmitting) buttonText = '예약 중...';
+  else if (!isLoggedIn) buttonText = '로그인 필요';
+  else if (isAuthor) buttonText = '예약 불가';
+  else buttonText = '예약하기';
 
   return (
     <div className='fixed bottom-0 left-0 z-50 w-full border-t border-[#E6E6E6] bg-white px-48 pt-18 pb-18 shadow-[0_-2px_10px_rgba(0,0,0,0.05)]'>
@@ -52,7 +51,7 @@ export default function ReservationBottomBar({
         variant='fill'
         onClick={onReserve}
       >
-        {getButtonText()}
+        {buttonText}
       </Button>
     </div>
   );

--- a/apps/what-today/src/components/activities/ReservationBottomBar.tsx
+++ b/apps/what-today/src/components/activities/ReservationBottomBar.tsx
@@ -12,6 +12,7 @@ export default function ReservationBottomBar({
   onReserve,
   isSubmitting = false,
   isAuthor = false,
+  isLoggedIn = true,
 }: ReservationBottomBarProps) {
   const totalPrice = reservation ? price * reservation.headCount : price;
   const formattedDateTime = reservation ? `${reservation.date} ${reservation.startTime} ~ ${reservation.endTime}` : '';
@@ -38,12 +39,17 @@ export default function ReservationBottomBar({
 
       <Button
         className='w-full'
-        disabled={!reservation || isSubmitting || isAuthor}
+        disabled={!reservation || isSubmitting || isAuthor || !isLoggedIn}
         size='lg'
         variant='fill'
         onClick={onReserve}
       >
-        {isSubmitting ? '예약 중...' : isAuthor ? '예약 불가' : '예약하기'}
+        {(() => {
+          if (isSubmitting) return '예약 중...';
+          if (!isLoggedIn) return '로그인 필요';
+          if (isAuthor) return '예약 불가';
+          return '예약하기';
+        })()}
       </Button>
     </div>
   );

--- a/apps/what-today/src/components/activities/ReservationBottomBar.tsx
+++ b/apps/what-today/src/components/activities/ReservationBottomBar.tsx
@@ -17,6 +17,14 @@ export default function ReservationBottomBar({
   const totalPrice = reservation ? price * reservation.headCount : price;
   const formattedDateTime = reservation ? `${reservation.date} ${reservation.startTime} ~ ${reservation.endTime}` : '';
 
+  // 버튼 텍스트 결정
+  const getButtonText = () => {
+    if (isSubmitting) return '예약 중...';
+    if (!isLoggedIn) return '로그인 필요';
+    if (isAuthor) return '예약 불가';
+    return '예약하기';
+  };
+
   return (
     <div className='fixed bottom-0 left-0 z-50 w-full border-t border-[#E6E6E6] bg-white px-48 pt-18 pb-18 shadow-[0_-2px_10px_rgba(0,0,0,0.05)]'>
       <div className='mb-12 flex items-center justify-between'>
@@ -44,12 +52,7 @@ export default function ReservationBottomBar({
         variant='fill'
         onClick={onReserve}
       >
-        {(() => {
-          if (isSubmitting) return '예약 중...';
-          if (!isLoggedIn) return '로그인 필요';
-          if (isAuthor) return '예약 불가';
-          return '예약하기';
-        })()}
+        {getButtonText()}
       </Button>
     </div>
   );

--- a/apps/what-today/src/components/activities/reservation/DesktopReservation.tsx
+++ b/apps/what-today/src/components/activities/reservation/DesktopReservation.tsx
@@ -6,7 +6,12 @@ import Divider from '../Divider';
 import ReservationForm from './ReservationForm';
 import type { DesktopReservationProps, ReservationRequest } from './types';
 
-export default function DesktopReservation({ activityId, price, schedules }: DesktopReservationProps) {
+export default function DesktopReservation({
+  activityId,
+  price,
+  schedules,
+  isAuthor = false,
+}: DesktopReservationProps) {
   const { toast } = useToast();
   const createReservationMutation = useCreateReservation(activityId);
 
@@ -35,6 +40,7 @@ export default function DesktopReservation({ activityId, price, schedules }: Des
     <section className='flex flex-col justify-between rounded-3xl border border-[#DDDDDD] p-30 shadow-sm'>
       <ReservationForm
         showSubmitButton
+        isAuthor={isAuthor}
         isSubmitting={createReservationMutation.isPending}
         price={price}
         schedules={schedules}

--- a/apps/what-today/src/components/activities/reservation/DesktopReservation.tsx
+++ b/apps/what-today/src/components/activities/reservation/DesktopReservation.tsx
@@ -11,6 +11,7 @@ export default function DesktopReservation({
   price,
   schedules,
   isAuthor = false,
+  isLoggedIn = true,
 }: DesktopReservationProps) {
   const { toast } = useToast();
   const createReservationMutation = useCreateReservation(activityId);
@@ -41,6 +42,7 @@ export default function DesktopReservation({
       <ReservationForm
         showSubmitButton
         isAuthor={isAuthor}
+        isLoggedIn={isLoggedIn}
         isSubmitting={createReservationMutation.isPending}
         price={price}
         schedules={schedules}

--- a/apps/what-today/src/components/activities/reservation/MobileReservationSheet.tsx
+++ b/apps/what-today/src/components/activities/reservation/MobileReservationSheet.tsx
@@ -108,7 +108,7 @@ export default function MobileReservationSheet({
                 variant='fill'
                 onClick={handleNextStep}
               >
-                {isAuthor ? '내가 만든 체험이에요' : '확인'}
+                {isAuthor ? '예약 불가' : '확인'}
               </Button>
             </div>
           </div>
@@ -162,7 +162,7 @@ export default function MobileReservationSheet({
                 variant='fill'
                 onClick={handleConfirm}
               >
-                {isAuthor ? '내가 만든 체험이에요' : '확인'}
+                {isAuthor ? '예약 불가' : '확인'}
               </Button>
             </div>
           </div>

--- a/apps/what-today/src/components/activities/reservation/MobileReservationSheet.tsx
+++ b/apps/what-today/src/components/activities/reservation/MobileReservationSheet.tsx
@@ -66,6 +66,20 @@ export default function MobileReservationSheet({
     }
   };
 
+  // 1단계 버튼 텍스트 결정
+  const getFirstStepButtonText = () => {
+    if (!isLoggedIn) return '로그인 필요';
+    if (isAuthor) return '예약 불가';
+    return '확인';
+  };
+
+  // 2단계 버튼 텍스트 결정
+  const getSecondStepButtonText = () => {
+    if (!isLoggedIn) return '로그인 필요';
+    if (isAuthor) return '예약 불가';
+    return '확인';
+  };
+
   return (
     <BottomSheet.Root isOpen={isOpen} onClose={handleClose}>
       {/* 1단계: 날짜/시간 선택 */}
@@ -109,11 +123,7 @@ export default function MobileReservationSheet({
                 variant='fill'
                 onClick={handleNextStep}
               >
-                {(() => {
-                  if (!isLoggedIn) return '로그인 필요';
-                  if (isAuthor) return '예약 불가';
-                  return '확인';
-                })()}
+                {getFirstStepButtonText()}
               </Button>
             </div>
           </div>
@@ -167,11 +177,7 @@ export default function MobileReservationSheet({
                 variant='fill'
                 onClick={handleConfirm}
               >
-                {(() => {
-                  if (!isLoggedIn) return '로그인 필요';
-                  if (isAuthor) return '예약 불가';
-                  return '확인';
-                })()}
+                {getSecondStepButtonText()}
               </Button>
             </div>
           </div>

--- a/apps/what-today/src/components/activities/reservation/MobileReservationSheet.tsx
+++ b/apps/what-today/src/components/activities/reservation/MobileReservationSheet.tsx
@@ -17,6 +17,7 @@ export default function MobileReservationSheet({
   onClose,
   onConfirm,
   isAuthor = false,
+  isLoggedIn = true,
 }: TabletReservationSheetProps) {
   const [currentStep, setCurrentStep] = useState<MobileStep>('dateTime');
 
@@ -103,12 +104,16 @@ export default function MobileReservationSheet({
             <div className='pt-8'>
               <Button
                 className='w-full'
-                disabled={!selectedScheduleId || isAuthor}
+                disabled={!selectedScheduleId || isAuthor || !isLoggedIn}
                 size='lg'
                 variant='fill'
                 onClick={handleNextStep}
               >
-                {isAuthor ? '예약 불가' : '확인'}
+                {(() => {
+                  if (!isLoggedIn) return '로그인 필요';
+                  if (isAuthor) return '예약 불가';
+                  return '확인';
+                })()}
               </Button>
             </div>
           </div>
@@ -157,12 +162,16 @@ export default function MobileReservationSheet({
             <div className='pt-8'>
               <Button
                 className='w-full'
-                disabled={!isReadyToReserve || isAuthor}
+                disabled={!isReadyToReserve || isAuthor || !isLoggedIn}
                 size='lg'
                 variant='fill'
                 onClick={handleConfirm}
               >
-                {isAuthor ? '예약 불가' : '확인'}
+                {(() => {
+                  if (!isLoggedIn) return '로그인 필요';
+                  if (isAuthor) return '예약 불가';
+                  return '확인';
+                })()}
               </Button>
             </div>
           </div>

--- a/apps/what-today/src/components/activities/reservation/MobileReservationSheet.tsx
+++ b/apps/what-today/src/components/activities/reservation/MobileReservationSheet.tsx
@@ -66,19 +66,11 @@ export default function MobileReservationSheet({
     }
   };
 
-  // 1단계 버튼 텍스트 결정
-  const getFirstStepButtonText = () => {
-    if (!isLoggedIn) return '로그인 필요';
-    if (isAuthor) return '예약 불가';
-    return '확인';
-  };
-
-  // 2단계 버튼 텍스트 결정
-  const getSecondStepButtonText = () => {
-    if (!isLoggedIn) return '로그인 필요';
-    if (isAuthor) return '예약 불가';
-    return '확인';
-  };
+  // 버튼 텍스트 결정 (1단계, 2단계 공통)
+  let buttonText = '';
+  if (!isLoggedIn) buttonText = '로그인 필요';
+  else if (isAuthor) buttonText = '예약 불가';
+  else buttonText = '확인';
 
   return (
     <BottomSheet.Root isOpen={isOpen} onClose={handleClose}>
@@ -123,7 +115,7 @@ export default function MobileReservationSheet({
                 variant='fill'
                 onClick={handleNextStep}
               >
-                {getFirstStepButtonText()}
+                {buttonText}
               </Button>
             </div>
           </div>
@@ -177,7 +169,7 @@ export default function MobileReservationSheet({
                 variant='fill'
                 onClick={handleConfirm}
               >
-                {getSecondStepButtonText()}
+                {buttonText}
               </Button>
             </div>
           </div>

--- a/apps/what-today/src/components/activities/reservation/MobileReservationSheet.tsx
+++ b/apps/what-today/src/components/activities/reservation/MobileReservationSheet.tsx
@@ -16,6 +16,7 @@ export default function MobileReservationSheet({
   isOpen,
   onClose,
   onConfirm,
+  isAuthor = false,
 }: TabletReservationSheetProps) {
   const [currentStep, setCurrentStep] = useState<MobileStep>('dateTime');
 
@@ -102,12 +103,12 @@ export default function MobileReservationSheet({
             <div className='pt-8'>
               <Button
                 className='w-full'
-                disabled={!selectedScheduleId}
+                disabled={!selectedScheduleId || isAuthor}
                 size='lg'
                 variant='fill'
                 onClick={handleNextStep}
               >
-                확인
+                {isAuthor ? '내가 만든 체험이에요' : '확인'}
               </Button>
             </div>
           </div>
@@ -154,8 +155,14 @@ export default function MobileReservationSheet({
 
             {/* 확인 버튼 */}
             <div className='pt-8'>
-              <Button className='w-full' disabled={!isReadyToReserve} size='lg' variant='fill' onClick={handleConfirm}>
-                확인
+              <Button
+                className='w-full'
+                disabled={!isReadyToReserve || isAuthor}
+                size='lg'
+                variant='fill'
+                onClick={handleConfirm}
+              >
+                {isAuthor ? '내가 만든 체험이에요' : '확인'}
               </Button>
             </div>
           </div>

--- a/apps/what-today/src/components/activities/reservation/ReservationForm.tsx
+++ b/apps/what-today/src/components/activities/reservation/ReservationForm.tsx
@@ -48,12 +48,11 @@ export default function ReservationForm({
   };
 
   // 버튼 텍스트 결정
-  const getButtonText = () => {
-    if (isSubmitting) return '예약 중...';
-    if (!isLoggedIn) return '로그인 필요';
-    if (isAuthor) return '예약 불가';
-    return '예약하기';
-  };
+  let buttonText = '';
+  if (isSubmitting) buttonText = '예약 중...';
+  else if (!isLoggedIn) buttonText = '로그인 필요';
+  else if (isAuthor) buttonText = '예약 불가';
+  else buttonText = '예약하기';
 
   return (
     <div className='flex flex-col gap-24'>
@@ -93,7 +92,7 @@ export default function ReservationForm({
             variant='fill'
             onClick={handleSubmit}
           >
-            {getButtonText()}
+            {buttonText}
           </Button>
         )}
       </div>

--- a/apps/what-today/src/components/activities/reservation/ReservationForm.tsx
+++ b/apps/what-today/src/components/activities/reservation/ReservationForm.tsx
@@ -84,7 +84,7 @@ export default function ReservationForm({
             variant='fill'
             onClick={handleSubmit}
           >
-            {isSubmitting ? '예약 중...' : isAuthor ? '내가 만든 체험' : '예약하기'}
+            {isSubmitting ? '예약 중...' : isAuthor ? '예약 불가' : '예약하기'}
           </Button>
         )}
       </div>

--- a/apps/what-today/src/components/activities/reservation/ReservationForm.tsx
+++ b/apps/what-today/src/components/activities/reservation/ReservationForm.tsx
@@ -47,6 +47,14 @@ export default function ReservationForm({
     });
   };
 
+  // 버튼 텍스트 결정
+  const getButtonText = () => {
+    if (isSubmitting) return '예약 중...';
+    if (!isLoggedIn) return '로그인 필요';
+    if (isAuthor) return '예약 불가';
+    return '예약하기';
+  };
+
   return (
     <div className='flex flex-col gap-24'>
       {/* 가격 표시 */}
@@ -85,12 +93,7 @@ export default function ReservationForm({
             variant='fill'
             onClick={handleSubmit}
           >
-            {(() => {
-              if (isSubmitting) return '예약 중...';
-              if (!isLoggedIn) return '로그인 필요';
-              if (isAuthor) return '예약 불가';
-              return '예약하기';
-            })()}
+            {getButtonText()}
           </Button>
         )}
       </div>

--- a/apps/what-today/src/components/activities/reservation/ReservationForm.tsx
+++ b/apps/what-today/src/components/activities/reservation/ReservationForm.tsx
@@ -13,6 +13,7 @@ export default function ReservationForm({
   onSubmit,
   showSubmitButton = false,
   isSubmitting: externalIsSubmitting,
+  isAuthor = false,
 }: ReservationFormProps) {
   const reservation = useReservation(schedules, price, {
     onReservationChange,
@@ -77,8 +78,13 @@ export default function ReservationForm({
         </p>
 
         {showSubmitButton && (
-          <Button disabled={!isReadyToReserve || isSubmitting} size='sm' variant='fill' onClick={handleSubmit}>
-            {isSubmitting ? '예약 중...' : '예약하기'}
+          <Button
+            disabled={!isReadyToReserve || isSubmitting || isAuthor}
+            size='sm'
+            variant='fill'
+            onClick={handleSubmit}
+          >
+            {isSubmitting ? '예약 중...' : isAuthor ? '내가 만든 체험' : '예약하기'}
           </Button>
         )}
       </div>

--- a/apps/what-today/src/components/activities/reservation/ReservationForm.tsx
+++ b/apps/what-today/src/components/activities/reservation/ReservationForm.tsx
@@ -14,6 +14,7 @@ export default function ReservationForm({
   showSubmitButton = false,
   isSubmitting: externalIsSubmitting,
   isAuthor = false,
+  isLoggedIn = true,
 }: ReservationFormProps) {
   const reservation = useReservation(schedules, price, {
     onReservationChange,
@@ -79,12 +80,17 @@ export default function ReservationForm({
 
         {showSubmitButton && (
           <Button
-            disabled={!isReadyToReserve || isSubmitting || isAuthor}
+            disabled={!isReadyToReserve || isSubmitting || isAuthor || !isLoggedIn}
             size='sm'
             variant='fill'
             onClick={handleSubmit}
           >
-            {isSubmitting ? '예약 중...' : isAuthor ? '예약 불가' : '예약하기'}
+            {(() => {
+              if (isSubmitting) return '예약 중...';
+              if (!isLoggedIn) return '로그인 필요';
+              if (isAuthor) return '예약 불가';
+              return '예약하기';
+            })()}
           </Button>
         )}
       </div>

--- a/apps/what-today/src/components/activities/reservation/TabletReservationSheet.tsx
+++ b/apps/what-today/src/components/activities/reservation/TabletReservationSheet.tsx
@@ -86,7 +86,7 @@ export default function TabletReservationSheet({
               }
             }}
           >
-            {isAuthor ? '내가 만든 체험이에요' : '확인'}
+            {isAuthor ? '예약 불가' : '확인'}
           </Button>
         </div>
       </BottomSheet.Content>

--- a/apps/what-today/src/components/activities/reservation/TabletReservationSheet.tsx
+++ b/apps/what-today/src/components/activities/reservation/TabletReservationSheet.tsx
@@ -30,11 +30,10 @@ export default function TabletReservationSheet({
   } = useReservation(schedules, price);
 
   // 버튼 텍스트 결정
-  const getButtonText = () => {
-    if (!isLoggedIn) return '로그인 필요';
-    if (isAuthor) return '예약 불가';
-    return '확인';
-  };
+  let buttonText = '';
+  if (!isLoggedIn) buttonText = '로그인 필요';
+  else if (isAuthor) buttonText = '예약 불가';
+  else buttonText = '확인';
 
   return (
     <BottomSheet.Root isOpen={isOpen} onClose={onClose}>
@@ -94,7 +93,7 @@ export default function TabletReservationSheet({
               }
             }}
           >
-            {getButtonText()}
+            {buttonText}
           </Button>
         </div>
       </BottomSheet.Content>

--- a/apps/what-today/src/components/activities/reservation/TabletReservationSheet.tsx
+++ b/apps/what-today/src/components/activities/reservation/TabletReservationSheet.tsx
@@ -12,6 +12,7 @@ export default function TabletReservationSheet({
   isOpen,
   onClose,
   onConfirm,
+  isAuthor = false,
 }: TabletReservationSheetProps) {
   const {
     selectedDate,
@@ -67,7 +68,7 @@ export default function TabletReservationSheet({
         <div className='px-20 pt-8 pb-24'>
           <Button
             className='w-full'
-            disabled={!isReadyToReserve}
+            disabled={!isReadyToReserve || isAuthor}
             size='lg'
             variant='fill'
             onClick={() => {
@@ -85,7 +86,7 @@ export default function TabletReservationSheet({
               }
             }}
           >
-            확인
+            {isAuthor ? '내가 만든 체험이에요' : '확인'}
           </Button>
         </div>
       </BottomSheet.Content>

--- a/apps/what-today/src/components/activities/reservation/TabletReservationSheet.tsx
+++ b/apps/what-today/src/components/activities/reservation/TabletReservationSheet.tsx
@@ -13,6 +13,7 @@ export default function TabletReservationSheet({
   onClose,
   onConfirm,
   isAuthor = false,
+  isLoggedIn = true,
 }: TabletReservationSheetProps) {
   const {
     selectedDate,
@@ -68,7 +69,7 @@ export default function TabletReservationSheet({
         <div className='px-20 pt-8 pb-24'>
           <Button
             className='w-full'
-            disabled={!isReadyToReserve || isAuthor}
+            disabled={!isReadyToReserve || isAuthor || !isLoggedIn}
             size='lg'
             variant='fill'
             onClick={() => {
@@ -86,7 +87,11 @@ export default function TabletReservationSheet({
               }
             }}
           >
-            {isAuthor ? '예약 불가' : '확인'}
+            {(() => {
+              if (!isLoggedIn) return '로그인 필요';
+              if (isAuthor) return '예약 불가';
+              return '확인';
+            })()}
           </Button>
         </div>
       </BottomSheet.Content>

--- a/apps/what-today/src/components/activities/reservation/TabletReservationSheet.tsx
+++ b/apps/what-today/src/components/activities/reservation/TabletReservationSheet.tsx
@@ -29,6 +29,13 @@ export default function TabletReservationSheet({
     reservableDates,
   } = useReservation(schedules, price);
 
+  // 버튼 텍스트 결정
+  const getButtonText = () => {
+    if (!isLoggedIn) return '로그인 필요';
+    if (isAuthor) return '예약 불가';
+    return '확인';
+  };
+
   return (
     <BottomSheet.Root isOpen={isOpen} onClose={onClose}>
       <BottomSheet.Content>
@@ -87,11 +94,7 @@ export default function TabletReservationSheet({
               }
             }}
           >
-            {(() => {
-              if (!isLoggedIn) return '로그인 필요';
-              if (isAuthor) return '예약 불가';
-              return '확인';
-            })()}
+            {getButtonText()}
           </Button>
         </div>
       </BottomSheet.Content>

--- a/apps/what-today/src/components/activities/reservation/types/index.ts
+++ b/apps/what-today/src/components/activities/reservation/types/index.ts
@@ -56,12 +56,14 @@ export interface ReservationFormProps {
   onSubmit?: (request: ReservationRequest) => Promise<void>;
   showSubmitButton?: boolean;
   isSubmitting?: boolean;
+  isAuthor?: boolean;
 }
 
 export interface DesktopReservationProps {
   activityId: number;
   price: number;
   schedules: Schedule[];
+  isAuthor?: boolean;
 }
 
 export interface TabletReservationSheetProps {
@@ -70,6 +72,7 @@ export interface TabletReservationSheetProps {
   isOpen: boolean;
   onClose: () => void;
   onConfirm: (summary: ReservationSummary) => void;
+  isAuthor?: boolean;
 }
 
 export interface ReservationBottomBarProps {
@@ -78,4 +81,5 @@ export interface ReservationBottomBarProps {
   onSelectDate: () => void;
   onReserve: () => void;
   isSubmitting?: boolean;
+  isAuthor?: boolean;
 }

--- a/apps/what-today/src/components/activities/reservation/types/index.ts
+++ b/apps/what-today/src/components/activities/reservation/types/index.ts
@@ -57,6 +57,7 @@ export interface ReservationFormProps {
   showSubmitButton?: boolean;
   isSubmitting?: boolean;
   isAuthor?: boolean;
+  isLoggedIn?: boolean;
 }
 
 export interface DesktopReservationProps {
@@ -64,6 +65,7 @@ export interface DesktopReservationProps {
   price: number;
   schedules: Schedule[];
   isAuthor?: boolean;
+  isLoggedIn?: boolean;
 }
 
 export interface TabletReservationSheetProps {
@@ -73,6 +75,7 @@ export interface TabletReservationSheetProps {
   onClose: () => void;
   onConfirm: (summary: ReservationSummary) => void;
   isAuthor?: boolean;
+  isLoggedIn?: boolean;
 }
 
 export interface ReservationBottomBarProps {
@@ -82,4 +85,5 @@ export interface ReservationBottomBarProps {
   onReserve: () => void;
   isSubmitting?: boolean;
   isAuthor?: boolean;
+  isLoggedIn?: boolean;
 }

--- a/apps/what-today/src/pages/activities/index.tsx
+++ b/apps/what-today/src/pages/activities/index.tsx
@@ -99,7 +99,12 @@ export default function ActivityDetailPage() {
                 reviewCount={activity.reviewCount}
                 title={activity.title}
               />
-              <DesktopReservation activityId={activity.id} price={activity.price} schedules={activity.schedules} />
+              <DesktopReservation
+                activityId={activity.id}
+                isAuthor={user?.id ? activity?.userId === user.id : false}
+                price={activity.price}
+                schedules={activity.schedules}
+              />
             </div>
           </div>
         ) : (
@@ -128,6 +133,7 @@ export default function ActivityDetailPage() {
       {!isDesktop && (
         <>
           <ReservationBottomBar
+            isAuthor={user?.id ? activity?.userId === user.id : false}
             isSubmitting={createReservationMutation.isPending}
             price={activity.price}
             reservation={
@@ -150,6 +156,7 @@ export default function ActivityDetailPage() {
           {/* 태블릿 바텀시트 */}
           {isTablet && (
             <TabletReservationSheet
+              isAuthor={user?.id ? activity?.userId === user.id : false}
               isOpen={isTabletSheetOpen}
               price={activity.price}
               schedules={activity.schedules}
@@ -161,6 +168,7 @@ export default function ActivityDetailPage() {
           {/* 모바일 바텀시트 */}
           {isMobile && (
             <MobileReservationSheet
+              isAuthor={user?.id ? activity?.userId === user.id : false}
               isOpen={isMobileSheetOpen}
               price={activity.price}
               schedules={activity.schedules}

--- a/apps/what-today/src/pages/activities/index.tsx
+++ b/apps/what-today/src/pages/activities/index.tsx
@@ -102,6 +102,7 @@ export default function ActivityDetailPage() {
               <DesktopReservation
                 activityId={activity.id}
                 isAuthor={user?.id ? activity?.userId === user.id : false}
+                isLoggedIn={!!user}
                 price={activity.price}
                 schedules={activity.schedules}
               />
@@ -134,6 +135,7 @@ export default function ActivityDetailPage() {
         <>
           <ReservationBottomBar
             isAuthor={user?.id ? activity?.userId === user.id : false}
+            isLoggedIn={!!user}
             isSubmitting={createReservationMutation.isPending}
             price={activity.price}
             reservation={
@@ -157,6 +159,7 @@ export default function ActivityDetailPage() {
           {isTablet && (
             <TabletReservationSheet
               isAuthor={user?.id ? activity?.userId === user.id : false}
+              isLoggedIn={!!user}
               isOpen={isTabletSheetOpen}
               price={activity.price}
               schedules={activity.schedules}
@@ -169,6 +172,7 @@ export default function ActivityDetailPage() {
           {isMobile && (
             <MobileReservationSheet
               isAuthor={user?.id ? activity?.userId === user.id : false}
+              isLoggedIn={!!user}
               isOpen={isMobileSheetOpen}
               price={activity.price}
               schedules={activity.schedules}


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- #186

## 📌 작업 내용
<!-- 해당 PR의 변경 사항을 자세하게 적어주세요.-->

- 상세페이지 드롭다운 클릭 영역이 너무 작아서 트리거 영역을 조금 늘렸습니다.
- 내가 생성한 체험은 예약할 수 없도록 구현했습니다(달력 선택, 시간 선택은 가능)
- 로그인 안한 유저는 예약할 수 없도록 구현했습니다(달력 선택, 시간 선택은 가능)

## ✅ 체크리스트

- [x] PR 하기 전에 이슈에서 빼먹은건 없는지 확인했습니다
  - [x] 라벨 및 마일스톤을 사이드 탭에서 등록했습니다.
- [x] PR을 보내는 브랜치가 올바른지 확인했습니다.
- [x] 팀원들이 리뷰하기 쉽도록 설명을 자세하게 작성했습니다.
- [x] 변경사항을 충분히 테스트 했습니다.
- [x] (함수를 구현 했을 때) JSDoc을 양식에 맞춰서 작성했습니다.
- [x] 컨벤션에 맞게 구현했습니다.

## 📷 UI 변경 사항 (선택)
<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->

<img width="112" height="80" alt="image" src="https://github.com/user-attachments/assets/4b34ac8c-3319-448b-a9ae-baef9969a28b" />

> 원래는 MoreIcon 영역 만큼만 선택 가능한 영역이였습니다.

<img width="327" height="527" alt="image" src="https://github.com/user-attachments/assets/73b055c2-0fce-4932-aa94-4d0c698e6a06" />

> 모바일, 태블릿, PC 통일감 있게 본인이 만든 체험일 경우 `예약 불가`로 나오게 한 뒤 버튼을 막았습니다.

<img width="331" height="538" alt="image" src="https://github.com/user-attachments/assets/b0496718-235c-470f-8750-f43d1f950ad9" />

> 모바일, 태블릿, PC 통일감 있게 본인이 만든 체험일 경우 `로그인 필요`로 나오게 한 뒤 버튼을 막았습니다.

## ❓무슨 문제가 발생했나요? (선택)


## 💬 기타 참고 사항 (선택)
<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 활동 삭제 시 성공 알림 토스트가 표시됩니다.
  * 예약 및 확인 버튼이 작성자이거나 로그인하지 않은 경우 비활성화되며, 버튼 문구가 상황에 따라 동적으로 변경됩니다(예: "로그인 필요", "예약 불가").
  
* **스타일**
  * 작성자 전용 드롭다운 메뉴 트리거에 스타일이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->