### PR TITLE
예약내역 라디오 수정, 예약카드 줄바꿈 수정

### DIFF
--- a/apps/what-today/src/pages/mypage/reservations-list/index.tsx
+++ b/apps/what-today/src/pages/mypage/reservations-list/index.tsx
@@ -200,14 +200,16 @@ export default function ReservationsListPage() {
       </header>
 
       <section className='mb-10'>
-        <RadioGroup selectedValue={selectedStatus} onSelect={(value) => setSelectedStatus(String(value))}>
-          <div className='flex flex-wrap gap-6'>
-            <RadioGroup.Radio value='pending'>예약 대기</RadioGroup.Radio>
-            <RadioGroup.Radio value='confirmed'>예약 승인</RadioGroup.Radio>
-            <RadioGroup.Radio value='declined'>예약 거절</RadioGroup.Radio>
-            <RadioGroup.Radio value='canceled'>예약 취소</RadioGroup.Radio>
-            <RadioGroup.Radio value='completed'>체험 완료</RadioGroup.Radio>
-          </div>
+        <RadioGroup
+          radioGroupClassName='flex flex-nowrap gap-6 overflow-x-auto no-scrollbar'
+          selectedValue={selectedStatus}
+          onSelect={(value) => setSelectedStatus(String(value))}
+        >
+          <RadioGroup.Radio value='pending'>예약 대기</RadioGroup.Radio>
+          <RadioGroup.Radio value='confirmed'>예약 승인</RadioGroup.Radio>
+          <RadioGroup.Radio value='declined'>예약 거절</RadioGroup.Radio>
+          <RadioGroup.Radio value='canceled'>예약 취소</RadioGroup.Radio>
+          <RadioGroup.Radio value='completed'>체험 완료</RadioGroup.Radio>
         </RadioGroup>
       </section>
 

--- a/packages/design-system/src/components/ReservationCard.tsx
+++ b/packages/design-system/src/components/ReservationCard.tsx
@@ -97,7 +97,7 @@ export default function ReservationCard({
         <div className='body-text text-gray-400'>
           <time>{startTime}</time>-<time>{endTime}</time>
         </div>
-        <div className='body-text mt-10 flex items-center gap-4 md:mt-0'>
+        <div className='body-text mt-10 flex flex-wrap items-center gap-4 md:mt-0'>
           <div className='font-bold'>₩{formatPrice(totalPrice)}</div>
           <div className='text-gray-400'>{formatPrice(headCount)}명</div>
         </div>


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- 이슈 번호

## 📌 작업 내용
<!-- 해당 PR의 변경 사항을 자세하게 적어주세요.-->

- 예약내역 라디오 줄바꿈 수정 -> 좌우 스크콜 모션 
- 예약카드 price headcount 숫자가 크면 content의 width가 커져서 줄 바꿈으로 일단 수정

## ✅ 체크리스트

- [x] PR 하기 전에 이슈에서 빼먹은건 없는지 확인했습니다
  - [x] 라벨 및 마일스톤을 사이드 탭에서 등록했습니다.
- [x] PR을 보내는 브랜치가 올바른지 확인했습니다.
- [x] 팀원들이 리뷰하기 쉽도록 설명을 자세하게 작성했습니다.
- [x] 변경사항을 충분히 테스트 했습니다.
- [x] (함수를 구현 했을 때) JSDoc을 양식에 맞춰서 작성했습니다.
- [x] 컨벤션에 맞게 구현했습니다.

## 📷 UI 변경 사항 (선택)
<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->



https://github.com/user-attachments/assets/50f7178b-a4d0-4c9a-83b9-2f7ffec40316


-줄바꿈 전

![2025-08-01_2 37 17](https://github.com/user-attachments/assets/b440ba08-c8d5-4ab2-ae24-ede48a232884)

- 줄바꿈 후

![2025-08-01_2 50 36](https://github.com/user-attachments/assets/b3200621-1293-4396-8344-3fb9ebddbb03)

## ❓무슨 문제가 발생했나요? (선택)

-

## 💬 기타 참고 사항 (선택)
<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->

-
