### PR TITLE
카카오 로그인 403 에러 처리

### DIFF
--- a/apps/what-today/src/hooks/useKakaoOAuth.ts
+++ b/apps/what-today/src/hooks/useKakaoOAuth.ts
@@ -55,6 +55,14 @@ export const useKakaoOAuth = ({ mode, onErrorRedirect }: UseKakaoOAuthOptions) =
           type: 'error',
         });
         navigate(onErrorRedirect || '/login');
+      } else if (message === '등록되지 않은 사용자입니다.' && mode === 'login') {
+        // 카카오 회원가입을 하지 않은 상태에서 바로 카카오 로그인을 시도했을 때 403 에러 발생
+        toast({
+          title: '로그인 오류',
+          description: '가입된 계정이 없습니다. 먼저 회원가입을 해주세요!',
+          type: 'error',
+        });
+        navigate('/signup');
       } else {
         console.error('인증 오류 발생:', error);
       }


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- #199

## 📌 작업 내용
<!-- 해당 PR의 변경 사항을 자세하게 적어주세요.-->

카카오 회원가입을 하지 않은 사용자가 바로 카카오 로그인을 시도하면 403 에러가 발생합니다.
403 에러 처리가 누락되어 카카오에서 리다이렉트한 페이지에 계속 머무는 이슈가 있었고,
카카오 로그인시 403(등록되지 않은 사용자)의 예외 처리를 진행했습니다. → 토스트 메시지 띄운 뒤 회원가입 페이지로 리다이렉트

## ✅ 체크리스트

- [x] PR 하기 전에 이슈에서 빼먹은건 없는지 확인했습니다
  - [x] 라벨 및 마일스톤을 사이드 탭에서 등록했습니다.
- [x] PR을 보내는 브랜치가 올바른지 확인했습니다.
- [x] 팀원들이 리뷰하기 쉽도록 설명을 자세하게 작성했습니다.
- [x] 변경사항을 충분히 테스트 했습니다.
- [x] (함수를 구현 했을 때) JSDoc을 양식에 맞춰서 작성했습니다.
- [x] 컨벤션에 맞게 구현했습니다.

## 📷 UI 변경 사항 (선택)
<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->

![카카오로그인403에러처리](https://github.com/user-attachments/assets/be8c890c-668e-4f8b-807e-4f11a8c5d391)


## ❓무슨 문제가 발생했나요? (선택)

-

## 💬 기타 참고 사항 (선택)
<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 카카오 로그인 시 등록되지 않은 사용자에 대한 오류 메시지 및 안내가 추가되어, 해당 경우 회원가입 페이지로 이동하도록 개선되었습니다.  
* **사용성 개선**
  * 로그인 및 회원가입 과정에서 발생하는 특정 오류에 대해 안내 메시지와 이동 경로가 보다 명확하게 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->