### PR TITLE
페이지 번역 기능 도입

### DIFF
--- a/apps/what-today/package.json
+++ b/apps/what-today/package.json
@@ -4,10 +4,10 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host",
     "build": "pnpm --filter @what-today/design-system... build && tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview --host"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.1.1",

--- a/apps/what-today/src/components/FlagIcon.tsx
+++ b/apps/what-today/src/components/FlagIcon.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+interface FlagIconProps {
+  flagCode: string;
+  alt?: string;
+  className?: string;
+  size?: 'sm' | 'md' | 'lg';
+}
+
+const FlagIcon: React.FC<FlagIconProps> = ({ flagCode, alt = 'Flag', className = '', size = 'md' }) => {
+  const sizeClasses = {
+    sm: 'w-30 h-30',
+    md: 'w-40 h-40',
+    lg: 'w-50 h-50',
+  };
+
+  const flagUrl = `https://cdn.weglot.com/flags/square/${flagCode}.svg`;
+
+  return (
+    <img
+      alt={alt}
+      className={`inline-block rounded-lg object-cover ${sizeClasses[size]} ${className}`}
+      src={flagUrl}
+      onError={(e) => {
+        // 이미지 로드 실패 시 기본 아이콘으로 대체
+        const target = e.target as HTMLImageElement;
+        target.src =
+          'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"/><path d="m9 9 5 12 1.5-2.75L17 16l-5-12-1.5 2.75L9 9z"/></svg>';
+      }}
+    />
+  );
+};
+
+export default FlagIcon;

--- a/apps/what-today/src/components/FloatingTranslateButton.tsx
+++ b/apps/what-today/src/components/FloatingTranslateButton.tsx
@@ -1,0 +1,317 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { twMerge } from 'tailwind-merge';
+
+import { findLanguageByCode, type Language, languages, supportedLanguageCodes } from '@/constants/languages';
+
+import FlagIcon from './FlagIcon';
+
+// 전역에서 스크립트 로드 상태 관리
+let isGoogleTranslateLoaded = false;
+let isGoogleTranslateLoading = false;
+
+interface FloatingTranslateButtonProps {
+  className?: string;
+}
+
+const FloatingTranslateButton: React.FC<FloatingTranslateButtonProps> = ({ className }) => {
+  const [selectedLanguage, setSelectedLanguage] = useState<Language>(languages[0]);
+  const [isReady, setIsReady] = useState(false);
+  const [currentTranslatedLang, setCurrentTranslatedLang] = useState<string>('ko');
+  const [isOpen, setIsOpen] = useState(false);
+  const initializationAttempted = useRef(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // 현재 번역된 언어 감지
+  const detectCurrentLanguage = useCallback(() => {
+    try {
+      // URL에서 현재 번역 언어 감지
+      const urlParams = new URLSearchParams(window.location.search);
+      const langFromUrl = urlParams.get('lang');
+
+      // Google Translate가 URL에 추가하는 언어 코드 확인
+      if (langFromUrl) {
+        setCurrentTranslatedLang(langFromUrl);
+        const foundLang = findLanguageByCode(langFromUrl);
+        if (foundLang) {
+          setSelectedLanguage(foundLang);
+        }
+        return;
+      }
+
+      // body 클래스에서 번역 상태 확인
+      const bodyClasses = document.body.className;
+      if (bodyClasses.includes('translated-')) {
+        const matches = bodyClasses.match(/translated-(\w+)/);
+        if (matches && matches[1]) {
+          const detectedLang = matches[1];
+          setCurrentTranslatedLang(detectedLang);
+          const foundLang = findLanguageByCode(detectedLang);
+          if (foundLang) {
+            setSelectedLanguage(foundLang);
+          }
+        }
+      }
+    } catch (error) {
+      console.warn('언어 감지 중 오류:', error);
+    }
+  }, []);
+
+  // Google Translate 위젯 초기화
+  const initializeGoogleTranslate = useCallback(() => {
+    if (initializationAttempted.current) return;
+
+    try {
+      initializationAttempted.current = true;
+
+      if ((window as any).google?.translate?.TranslateElement) {
+        // 기존 번역 요소가 있다면 제거
+        const existingElement = document.getElementById('google_translate_element');
+        if (existingElement) {
+          existingElement.innerHTML = '';
+        }
+
+        new (window as any).google.translate.TranslateElement(
+          {
+            pageLanguage: 'auto',
+            autoDisplay: false,
+            includedLanguages: supportedLanguageCodes,
+            layout: 0,
+          },
+          'google_translate_element',
+        );
+
+        setIsReady(true);
+
+        // 초기화 후 현재 언어 감지
+        setTimeout(() => {
+          detectCurrentLanguage();
+        }, 300);
+      }
+    } catch (error) {
+      console.error('Google Translate 초기화 실패:', error);
+      initializationAttempted.current = false;
+    }
+  }, [detectCurrentLanguage]);
+
+  // Google Translate 스크립트 로드
+  useEffect(() => {
+    if (isGoogleTranslateLoaded) {
+      initializeGoogleTranslate();
+      return;
+    }
+
+    if (isGoogleTranslateLoading) return;
+
+    isGoogleTranslateLoading = true;
+
+    // 콜백 함수를 window에 등록
+    (window as any).googleTranslateElementInit = () => {
+      isGoogleTranslateLoaded = true;
+      isGoogleTranslateLoading = false;
+
+      // 약간의 지연 후 초기화 (DOM이 준비될 시간 제공)
+      setTimeout(() => {
+        initializeGoogleTranslate();
+      }, 100);
+    };
+
+    // 기존 스크립트가 있는지 확인
+    const existingScript = document.querySelector('script[src*="translate.google.com"]');
+    if (!existingScript) {
+      const script = document.createElement('script');
+      script.src = 'https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit';
+      script.async = true;
+      script.onerror = () => {
+        console.error('Google Translate 스크립트 로드 실패');
+        isGoogleTranslateLoading = false;
+      };
+      document.head.appendChild(script);
+    }
+  }, [initializeGoogleTranslate]);
+
+  // URL 변경 감지 (번역 후 URL이 변경되므로)
+  useEffect(() => {
+    const handleLocationChange = () => {
+      setTimeout(() => {
+        detectCurrentLanguage();
+      }, 500);
+    };
+
+    window.addEventListener('popstate', handleLocationChange);
+    return () => {
+      window.removeEventListener('popstate', handleLocationChange);
+    };
+  }, [detectCurrentLanguage]);
+
+  // 외부 클릭 감지로 드롭다운 닫기
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [isOpen]);
+
+  // 언어 변경 함수
+  const changeLanguage = useCallback(
+    (language: Language) => {
+      if (!isReady) {
+        console.warn('Google Translate가 아직 준비되지 않았습니다.');
+        return;
+      }
+
+      try {
+        // 이미 선택된 언어인 경우 무시
+        if (currentTranslatedLang === language.code) {
+          return;
+        }
+
+        // 여러 방법으로 select 요소 찾기
+        let selectElement = document.querySelector('.goog-te-combo') as HTMLSelectElement;
+
+        if (!selectElement) {
+          // iframe 내부에서 찾기
+          const iframe = document.querySelector('iframe.goog-te-banner-frame') as HTMLIFrameElement;
+          if (iframe && iframe.contentDocument) {
+            selectElement = iframe.contentDocument.querySelector('.goog-te-combo') as HTMLSelectElement;
+          }
+        }
+
+        if (!selectElement) {
+          // 다른 selector로 재시도
+          selectElement = document.querySelector('select.goog-te-combo') as HTMLSelectElement;
+        }
+
+        if (selectElement) {
+          // 한국어 선택 시 번역 끄기 (원본 상태로 되돌리기)
+          if (language.code === 'ko') {
+            try {
+              // select 초기화
+              const selectElement = document.querySelector('.goog-te-combo') as HTMLSelectElement;
+              if (selectElement) {
+                selectElement.value = '';
+                selectElement.dispatchEvent(new Event('change', { bubbles: true }));
+              }
+
+              // 쿠키 제거
+              document.cookie = `googtrans=;path=/;expires=Thu, 01 Jan 1970 00:00:00 GMT;`;
+              document.cookie = `googtrans=;domain=.${window.location.hostname};path=/;expires=Thu, 01 Jan 1970 00:00:00 GMT;`;
+
+              // iframe 숨기기
+              const bannerIframe = document.querySelector('iframe.goog-te-banner-frame') as HTMLIFrameElement;
+              if (bannerIframe?.parentElement) {
+                bannerIframe.parentElement.style.display = 'none';
+              }
+
+              // body class 제거
+              document.body.className = document.body.className
+                .split(' ')
+                .filter((cls) => !cls.startsWith('translated-'))
+                .join(' ');
+
+              // ✅ 최종: URL 파라미터 제거 & 페이지 새로고침
+              const newUrl = window.location.origin + window.location.pathname;
+              window.location.href = newUrl;
+            } catch (error) {
+              console.error('원문 복귀 실패:', error);
+            }
+
+            return;
+          }
+          // 다른 언어에서 다른 언어로 변경 시 (한국어가 아닌 경우)
+          else if (currentTranslatedLang !== 'ko' && language.code !== 'ko') {
+            selectElement.value = '';
+            selectElement.dispatchEvent(new Event('change', { bubbles: true }));
+
+            // 잠시 후 목표 언어로 변경
+            setTimeout(() => {
+              selectElement.value = language.code;
+              selectElement.dispatchEvent(new Event('change', { bubbles: true }));
+              setCurrentTranslatedLang(language.code);
+              setSelectedLanguage(language);
+              setIsOpen(false);
+            }, 300);
+          }
+          // 한국어에서 다른 언어로 직접 변경 또는 일반적인 변경
+          else {
+            selectElement.value = language.code;
+            selectElement.dispatchEvent(new Event('change', { bubbles: true }));
+            setCurrentTranslatedLang(language.code);
+            setSelectedLanguage(language);
+            setIsOpen(false);
+          }
+        } else {
+          console.error('Google Translate select 요소를 찾을 수 없습니다.');
+          // 초기화 재시도
+          initializationAttempted.current = false;
+          setTimeout(() => initializeGoogleTranslate(), 500);
+        }
+      } catch (error) {
+        console.error('언어 변경 중 오류:', error);
+      }
+    },
+    [isReady, currentTranslatedLang, initializeGoogleTranslate],
+  );
+
+  // 버튼 클릭 핸들러
+  const handleButtonClick = () => {
+    setIsOpen(!isOpen);
+  };
+
+  return (
+    <>
+      {/* 숨겨진 Google Translate 요소 */}
+      <div className='hidden' id='google_translate_element' />
+
+      {/* 플로팅 번역 버튼 */}
+      <div ref={containerRef} className={twMerge('fixed right-10 bottom-10 z-50', className)}>
+        {/* 언어 선택 드롭다운 */}
+        {isOpen && (
+          <div className='absolute right-0 bottom-60 flex h-300 w-160 transform flex-col rounded-xl border border-gray-50 bg-white p-2 transition-all duration-200 ease-out'>
+            <div className='caption-text mb-2 p-2'>언어 선택</div>
+            <div className='flex-1 space-y-4 overflow-y-auto px-3 py-2'>
+              {languages.map((language) => (
+                <button
+                  key={language.code}
+                  className={`body-text flex w-full items-center gap-5 rounded-lg px-4 py-3 text-left transition-all hover:bg-gray-50 ${
+                    currentTranslatedLang === language.code
+                      ? 'text-primary-500 bg-blue-50 ring-1 ring-blue-200'
+                      : 'text-gray-90'
+                  }`}
+                  type='button'
+                  onClick={() => changeLanguage(language)}
+                >
+                  <FlagIcon alt={language.name} flagCode={language.flag} />
+                  <span className='flex-1 text-left'>{language.name}</span>
+                  {currentTranslatedLang === language.code && <span className='text-primary-500 pr-4'>✓</span>}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* 플로팅 버튼 */}
+        <button
+          className={`flex h-40 w-40 items-center justify-center rounded-lg bg-white shadow-lg transition-all hover:shadow-xl focus:ring-2 focus:ring-gray-50 focus:ring-offset-2 focus:outline-none ${
+            isOpen ? 'ring-2 ring-gray-50' : ''
+          }`}
+          type='button'
+          onClick={handleButtonClick}
+        >
+          <FlagIcon alt={selectedLanguage.name} flagCode={selectedLanguage.flag} size='md' />
+        </button>
+      </div>
+    </>
+  );
+};
+
+export default FloatingTranslateButton;

--- a/apps/what-today/src/constants/languages.ts
+++ b/apps/what-today/src/constants/languages.ts
@@ -1,0 +1,77 @@
+export interface Language {
+  code: string;
+  name: string;
+  flag: string;
+}
+
+export const languages: Language[] = [
+  { code: 'ko', name: '한국어', flag: 'kr' }, // 한국어
+  { code: 'en', name: 'English', flag: 'us' }, // 영어
+  { code: 'fr', name: 'Français', flag: 'fr' }, // 프랑스어
+  { code: 'de', name: 'Deutsch', flag: 'de' }, // 독일어
+  { code: 'zh-TW', name: '中文(繁體)', flag: 'tw' }, // 중국어(번체, 대만)
+  { code: 'ja', name: '日本語', flag: 'jp' }, // 일본어
+  { code: 'es', name: 'Español', flag: 'es' }, // 스페인어
+  { code: 'ru', name: 'Русский', flag: 'ru' }, // 러시아어
+  { code: 'it', name: 'Italiano', flag: 'it' }, // 이탈리아어
+  { code: 'pt', name: 'Português', flag: 'pt' }, // 포르투갈어
+  { code: 'ar', name: 'العربية', flag: 'sa' }, // 아랍어
+  { code: 'hi', name: 'हिन्दी', flag: 'in' }, // 힌디어
+  { code: 'th', name: 'ไทย', flag: 'th' }, // 태국어
+  { code: 'tr', name: 'Türkçe', flag: 'tr' }, // 터키어
+  { code: 'el', name: 'Ελληνικά', flag: 'gr' }, // 그리스어
+  { code: 'vi', name: 'Tiếng Việt', flag: 'vn' }, // 베트남어
+  { code: 'ms', name: 'Bahasa Melayu', flag: 'my' }, // 말레이어
+  { code: 'bn', name: 'বাংলা', flag: 'bd' }, // 벵골어
+  { code: 'sv', name: 'Svenska', flag: 'se' }, // 스웨덴어
+  { code: 'no', name: 'Norsk', flag: 'no' }, // 노르웨이어
+  { code: 'fi', name: 'Suomi', flag: 'fi' }, // 핀란드어
+  { code: 'da', name: 'Dansk', flag: 'dk' }, // 덴마크어
+  { code: 'nl', name: 'Nederlands', flag: 'nl' }, // 네덜란드어
+  { code: 'pl', name: 'Polski', flag: 'pl' }, // 폴란드어
+  { code: 'cs', name: 'Čeština', flag: 'cz' }, // 체코어
+  { code: 'hu', name: 'Magyar', flag: 'hu' }, // 헝가리어
+  { code: 'ro', name: 'Română', flag: 'ro' }, // 루마니아어
+  { code: 'sk', name: 'Slovenčina', flag: 'sk' }, // 슬로바키아어
+  { code: 'bg', name: 'Български', flag: 'bg' }, // 불가리아어
+  { code: 'hr', name: 'Hrvatski', flag: 'hr' }, // 크로아티아어
+  { code: 'uk', name: 'Українська', flag: 'ua' }, // 우크라이나어
+  { code: 'fa', name: 'فارسی', flag: 'ir' }, // 페르시아어
+  { code: 'sw', name: 'Kiswahili', flag: 'ke' }, // 스와힐리어
+  { code: 'tl', name: 'Tagalog', flag: 'ph' }, // 타갈로그어
+  { code: 'ur', name: 'اردو', flag: 'pk' }, // 우르두어
+  { code: 'am', name: 'አማርኛ', flag: 'et' }, // 암하라어
+  { code: 'az', name: 'Azərbaycan', flag: 'az' }, // 아제르바이잔어
+  { code: 'kk', name: 'Қазақ тілі', flag: 'kz' }, // 카자흐어
+  { code: 'uz', name: 'Oʻzbekcha', flag: 'uz' }, // 우즈베크어
+  { code: 'ka', name: 'ქართული', flag: 'ge' }, // 그루지야어 (조지아)
+  { code: 'pa', name: 'ਪੰਜਾਬੀ', flag: 'in' }, // 펀자브어 (인도)
+  { code: 'mr', name: 'मराठी', flag: 'in' }, // 마라티어 (인도)
+  { code: 'ta', name: 'தமிழ்', flag: 'in' }, // 타밀어 (인도)
+  { code: 'te', name: 'తెలుగు', flag: 'in' }, // 텔루구어 (인도)
+  { code: 'kn', name: 'ಕನ್ನಡ', flag: 'in' }, // 칸나다어 (인도)
+  { code: 'ml', name: 'മലയാളം', flag: 'in' }, // 말라얄람어 (인도)
+  { code: 'si', name: 'සිංහල', flag: 'lk' }, // 싱할라어 (스리랑카)
+  { code: 'my', name: 'မြန်မာ', flag: 'mm' }, // 미얀마어
+  { code: 'km', name: 'ភាសាខ្មែរ', flag: 'kh' }, // 크메르어 (캄보디아)
+  { code: 'lo', name: 'ລາວ', flag: 'la' }, // 라오스어
+  { code: 'mn', name: 'Монгол', flag: 'mn' }, // 몽골어
+  { code: 'ne', name: 'नेपाली', flag: 'np' }, // 네팔어
+  { code: 'tg', name: 'Тоҷикӣ', flag: 'tj' }, // 타지크어
+  { code: 'ps', name: 'پښتو', flag: 'af' }, // 파슈토어 (아프가니스탄)
+  { code: 'sq', name: 'Shqip', flag: 'al' }, // 알바니아어
+  { code: 'hy', name: 'Հայերեն', flag: 'am' }, // 아르메니아어
+];
+
+// Google Translate에서 지원하는 언어 코드 목록 (includedLanguages용)
+export const supportedLanguageCodes = languages.map((lang) => lang.code).join(',');
+
+// 언어 코드로 언어 정보 찾기 헬퍼 함수
+export const findLanguageByCode = (code: string): Language | undefined => {
+  return languages.find((lang) => lang.code === code);
+};
+
+// 국기 이미지 URL 생성 헬퍼 함수
+export const getFlagImageUrl = (flagCode: string): string => {
+  return `https://cdn.weglot.com/flags/square/${flagCode}.svg`;
+};

--- a/apps/what-today/src/index.css
+++ b/apps/what-today/src/index.css
@@ -86,3 +86,121 @@
     @apply text-[0.75rem] font-normal md:text-[0.875rem]; /* 12px → 14px */
   }
 }
+
+/* === Google Translate 숨김 스타일 === */
+/* 모든 Google Translate 관련 요소 숨기기 */
+.goog-te-banner-frame,
+.goog-te-banner-frame.skiptranslate,
+.goog-te-banner,
+.goog-te-banner * {
+  display: none !important;
+  visibility: hidden !important;
+  opacity: 0 !important;
+  position: absolute !important;
+  left: -9999px !important;
+  width: 0 !important;
+  height: 0 !important;
+  overflow: hidden !important;
+}
+
+/* Google 로고와 관련 링크 숨기기 */
+.goog-logo-link,
+.goog-te-gadget .goog-te-gadget-simple,
+.goog-te-menu-value,
+.goog-te-gadget-simple,
+.goog-te-menu-value span,
+.goog-te-menu-value:before {
+  display: none !important;
+  visibility: hidden !important;
+}
+
+/* 기본 select 요소와 gadget 완전 숨기기 */
+.goog-te-gadget,
+.goog-te-gadget-simple,
+.goog-te-gadget-icon {
+  display: none !important;
+  visibility: hidden !important;
+}
+
+/* iframe 숨기기 */
+iframe.goog-te-banner-frame,
+iframe.skiptranslate {
+  display: none !important;
+  visibility: hidden !important;
+  position: absolute !important;
+  left: -9999px !important;
+}
+
+/* 페이지 상단 여백 제거 및 위치 고정 */
+body {
+  top: 0px !important;
+  position: static !important;
+}
+
+/* body에 추가되는 translated 클래스 스타일 보정 */
+body.translated {
+  top: 0px !important;
+  position: static !important;
+}
+
+/* Google Translate에서 추가하는 상단 여백 제거 */
+html {
+  margin-top: 0px !important;
+}
+
+/* 추가적인 Google Translate 요소들 숨기기 */
+#goog-gt-,
+[id^='goog-gt-'],
+.goog-te-spinner-pos,
+.goog-te-spinner,
+.goog-te-ftab,
+.goog-te-ftab-float,
+.goog-te-loading,
+.goog-te-ballon-frame,
+.goog-te-ballon,
+.goog-te-combo-loader,
+.goog-te-progress,
+.skiptranslate,
+#google_translate_element .goog-te-gadget-simple,
+#google_translate_element .goog-te-gadget,
+#google_translate_element > div {
+  display: none !important;
+  visibility: hidden !important;
+  opacity: 0 !important;
+  position: absolute !important;
+  left: -9999px !important;
+  width: 0 !important;
+  height: 0 !important;
+  overflow: hidden !important;
+  z-index: -1 !important;
+}
+
+/* select 요소는 숨기되 기능은 유지 */
+#google_translate_element select.goog-te-combo {
+  opacity: 0 !important;
+  position: absolute !important;
+  left: -9999px !important;
+  width: 1px !important;
+  height: 1px !important;
+  pointer-events: none !important;
+}
+
+/* VoiceOver와 접근성을 위한 스크린 리더 전용 텍스트 */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.VIpgJd-ZVi9od-aZ2wEe-wOHMyf {
+  display: none !important;
+  visibility: hidden !important;
+  position: absolute !important;
+  left: -9999px !important;
+}

--- a/apps/what-today/src/layouts/DefaultLayout.tsx
+++ b/apps/what-today/src/layouts/DefaultLayout.tsx
@@ -1,6 +1,7 @@
 import { Footer } from '@what-today/design-system';
 import { Outlet, useLocation } from 'react-router-dom';
 
+import FloatingTranslateButton from '@/components/FloatingTranslateButton';
 import Header from '@/components/Header';
 import { useResponsive } from '@/hooks/useResponsive';
 
@@ -11,8 +12,11 @@ export default function DefaultLayout() {
 
   const footerMarginBottom = isActivityDetailPage && !isDesktop ? 'w-full mb-125' : 'w-full';
 
+  // FloatingTranslateButton의 bottom 위치 조건부 설정
+  const floatingButtonClass = !isDesktop && isActivityDetailPage ? 'bottom-140' : undefined;
+
   return (
-    <div className='flex w-full flex-col items-center gap-8 bg-white'>
+    <div className='flex w-full flex-col items-center gap-8 overflow-x-hidden'>
       <header className='w-full max-w-7xl px-[5vw]'>
         <Header />
       </header>
@@ -29,6 +33,9 @@ export default function DefaultLayout() {
       <div className={footerMarginBottom}>
         <Footer />
       </div>
+
+      {/* 플로팅 번역 버튼 */}
+      <FloatingTranslateButton className={floatingButtonClass} />
     </div>
   );
 }

--- a/apps/what-today/src/vite-env.d.ts
+++ b/apps/what-today/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+// Google Translate 타입 선언 (any로 단순화)
+declare global {
+  interface Window {
+    google: any;
+    googleTranslateElementInit: any;
+  }
+}


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- #193 

## 📌 작업 내용
<!-- 해당 PR의 변경 사항을 자세하게 적어주세요.-->

- 구글 번역 스크립트를 사용해서 (한국어 제외) 55개 언어로 번역이 가능하도록 했습니다.

## ✅ 체크리스트

- [x] PR 하기 전에 이슈에서 빼먹은건 없는지 확인했습니다
  - [x] 라벨 및 마일스톤을 사이드 탭에서 등록했습니다.
- [x] PR을 보내는 브랜치가 올바른지 확인했습니다.
- [x] 팀원들이 리뷰하기 쉽도록 설명을 자세하게 작성했습니다.
- [x] 변경사항을 충분히 테스트 했습니다.
- [x] (함수를 구현 했을 때) JSDoc을 양식에 맞춰서 작성했습니다.
- [x] 컨벤션에 맞게 구현했습니다.

## 📷 UI 변경 사항 (선택)
<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->


https://github.com/user-attachments/assets/5e080120-222e-4320-b104-2c7f0e3b99a5



## ❓무슨 문제가 발생했나요? (선택)

- 중국어 (간체)가 번역 안되는건 좀 아쉽네요...

## 💬 기타 참고 사항 (선택)
<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 페이지에 구글 번역을 사용할 수 있는 플로팅 번역 버튼이 추가되었습니다.
  * 각 언어를 국기 아이콘과 함께 선택할 수 있는 드롭다운 메뉴가 제공됩니다.

* **스타일**
  * 구글 번역 위젯 및 관련 UI 요소들이 모두 숨겨져 깔끔한 화면을 유지합니다.

* **기타**
  * 번역 버튼이 모든 페이지 레이아웃에 적용되었습니다.
  * 다양한 언어와 국기 정보가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->