### PR TITLE
♻️[#216] Refactor: 메인카드 카테고리 추가 및 높이수정

### DIFF
--- a/apps/what-today/src/pages/main/index.tsx
+++ b/apps/what-today/src/pages/main/index.tsx
@@ -138,6 +138,7 @@ export default function MainPage() {
       <MemoizedMainCard
         key={`${item.id}-${currentPage}-${index}`}
         bannerImageUrl={item.bannerImageUrl}
+        category={item.category}
         price={item.price}
         rating={item.rating}
         reviewCount={item.reviewCount}
@@ -159,7 +160,7 @@ export default function MainPage() {
         {/* 인기 체험 */}
         <div className='flex flex-col gap-20'>
           <h2 className='title-text'>🔥 인기 체험</h2>
-          <div className='-mx-15 flex'>
+          <div className='flex'>
             <Carousel items={popularActivities} itemsPerPage={4} onClick={(id) => navigate(`/activities/${id}`)} />
           </div>
         </div>

--- a/packages/design-system/src/components/Carousel/Carousel.tsx
+++ b/packages/design-system/src/components/Carousel/Carousel.tsx
@@ -30,7 +30,7 @@ export default function Carousel({ items, itemsPerPage: initialItemsPerPage = 4,
 
   return (
     <div className='relative w-full overflow-visible'>
-      <div className='relative mx-auto flex max-w-6xl items-center justify-center'>
+      <div className='relative mx-auto flex items-center justify-center'>
         {/* 왼쪽 버튼 */}
         <NavigationButton direction='left' disabled={page === 0} onClick={handlePrev} />
 
@@ -50,6 +50,7 @@ export default function Carousel({ items, itemsPerPage: initialItemsPerPage = 4,
               >
                 <MainCard.Root
                   bannerImageUrl={item.bannerImageUrl}
+                  category={item.category}
                   price={item.price}
                   rating={item.rating}
                   reviewCount={item.reviewCount}
@@ -77,6 +78,7 @@ export default function Carousel({ items, itemsPerPage: initialItemsPerPage = 4,
             <MainCard.Root
               key={item.id}
               bannerImageUrl={item.bannerImageUrl}
+              category={item.category}
               className='w-265 shrink-0'
               price={item.price}
               rating={item.rating}

--- a/packages/design-system/src/components/Carousel/types/index.ts
+++ b/packages/design-system/src/components/Carousel/types/index.ts
@@ -28,4 +28,5 @@ export interface CarouselProps {
   rating: number;
   reviewCount: number;
   bannerImageUrl: string;
+  category: string;
 }

--- a/packages/design-system/src/components/MainCard/Content.tsx
+++ b/packages/design-system/src/components/MainCard/Content.tsx
@@ -18,7 +18,7 @@ export default function MainCardContent({
   priceClassName,
   iconColor = '#FFC23D',
 }: Props) {
-  const { title, price, rating, reviewCount } = useMainCardContext();
+  const { title, price, rating, reviewCount, category } = useMainCardContext();
 
   return (
     <div className='absolute bottom-0 left-0 w-full'>
@@ -28,18 +28,23 @@ export default function MainCardContent({
           className,
         )}
       >
-        <div className='flex flex-col gap-4'>
-          <h3 className={twMerge('body-text line-clamp-1 truncate font-bold', titleClassName)}>{title}</h3>
-          <div className='caption-text flex items-center gap-2'>
-            <StarIcon filled className='size-15' color={iconColor} />
-            <span className={twMerge('', ratingClassName)}>{rating}</span>
-            <div className='text-gray-400'>({reviewCount.toLocaleString()})</div>
+        <div className='flex flex-col gap-20'>
+          <div className='flex flex-col gap-2'>
+            <span className='caption-text text-gray-400'>{category}</span>
+            <h3 className={twMerge('body-text line-clamp-1 truncate font-bold', titleClassName)}>{title}</h3>
+            <div className='caption-text flex items-center gap-2'>
+              <StarIcon filled className='size-15' color={iconColor} />
+              <span className={twMerge('', ratingClassName)}>{rating}</span>
+              <div className='text-gray-400'>({reviewCount.toLocaleString()})</div>
+            </div>
+          </div>
+          <div>
+            <p className={twMerge('body-text font-bold', priceClassName)}>
+              ₩ {price.toLocaleString()}
+              <span className='font-normal text-gray-400'> /인</span>
+            </p>
           </div>
         </div>
-        <p className={twMerge('body-text font-bold', priceClassName)}>
-          ₩ {price.toLocaleString()}
-          <span className='font-normal text-gray-400'> /인</span>
-        </p>
       </div>
     </div>
   );

--- a/packages/design-system/src/components/MainCard/Image.tsx
+++ b/packages/design-system/src/components/MainCard/Image.tsx
@@ -8,7 +8,7 @@ export default function MainCardImage({ className }: { className?: string }) {
     <div className={twMerge('w-full rounded-xl border border-gray-50', className)}>
       <img
         alt={`${title} 체험 이미지`}
-        className='h-260 w-full rounded-xl object-cover md:h-366 lg:h-300'
+        className='h-260 w-full rounded-xl object-cover md:h-366 lg:h-340'
         loading='lazy'
         src={bannerImageUrl}
       />

--- a/packages/design-system/src/components/MainCard/MainCardRoot.tsx
+++ b/packages/design-system/src/components/MainCard/MainCardRoot.tsx
@@ -11,10 +11,11 @@ export default function MainCardRoot({
   reviewCount,
   children,
   className,
+  category,
   onClick,
 }: MainCardProps) {
   return (
-    <MainCardContext.Provider value={{ title, price, bannerImageUrl, rating, reviewCount, onClick }}>
+    <MainCardContext.Provider value={{ title, price, bannerImageUrl, rating, reviewCount, category, onClick }}>
       <div className='rounded-xl'>
         <div
           className={twMerge(

--- a/packages/design-system/src/components/MainCard/types/index.tsx
+++ b/packages/design-system/src/components/MainCard/types/index.tsx
@@ -15,6 +15,7 @@ export interface MainCardContextType {
   bannerImageUrl: string;
   rating: number;
   reviewCount: number;
+  category: string;
   onClick?: () => void;
 }
 

--- a/packages/design-system/src/pages/MainCardDoc.tsx
+++ b/packages/design-system/src/pages/MainCardDoc.tsx
@@ -5,7 +5,7 @@ import DocTemplate, { DocCode } from '../layouts/DocTemplate';
 
 /* Playground는 편집 가능한 코드 블록입니다. */
 /* Playground에서 사용할 예시 코드를 작성해주세요. */
-const code = `<MainCard
+const code = `<MainCard.Root
   title='스카이다이빙'
   price={200000}
   bannerImageUrl='https://images.unsplash.com/photo-1506744038136-46273834b3fb?auto=format&fit=crop&w=1000&q=80'
@@ -15,7 +15,7 @@ const code = `<MainCard
 >
   <MainCard.Image />
   <MainCard.Content />
-</MainCard>`;
+</MainCard.Root>`;
 
 export default function MainCardDoc() {
   return (
@@ -59,24 +59,26 @@ Main에서 쓰이는 인기체험 모든체험 Card입니다.
       </div>
       <h3 className='text-2xl'>기본 MainCard 예시 입니다.</h3>
       <DocCode
-        code={`        <MainCard
+        code={`        <MainCard.Root
         title='스카이다이빙'
         price={200000}
         bannerImageUrl='https://images.unsplash.com/photo-1506744038136-46273834b3fb?auto=format&fit=crop&w=1000&q=80'
         rating={4.8}
         reviewCount={121}
+        category="식음료"
         className='w-[265px]'
       >
         <MainCard.Image />
         <MainCard.Content />
-      </MainCard>`}
+      </MainCard.Root>`}
       />
 
       <h3 className='text-2xl'>커스텀 MainCard 예시 입니다.</h3>
 
-      <div>
+      <div className='flex gap-20'>
         <MainCard.Root
           bannerImageUrl='https://images.unsplash.com/photo-1506744038136-46273834b3fb?auto=format&fit=crop&w=1000&q=80'
+          category='식음료'
           className='w-[265px]'
           price={200000}
           rating={4.8}
@@ -85,22 +87,35 @@ Main에서 쓰이는 인기체험 모든체험 Card입니다.
         >
           <MainCard.Image className='rounded-t-3xl brightness-90 contrast-125' />
           <MainCard.Content
-            className='rounded-b-3xl border-t border-white/10 bg-gradient-to-t from-black/60 to-transparent px-16 py-12 shadow-xl'
+            className='rounded-b-3xl border-t border-white/10 bg-gradient-to-t from-black/60 to-transparent px-16 py-12 text-white shadow-xl'
             iconColor='#FFD700' // 골드 컬러
             priceClassName='text-pink-400 font-bold text-lg'
             ratingClassName='text-emerald-300 font-semibold'
             titleClassName='text-white font-extrabold tracking-wider drop-shadow-[0_2px_2px_rgba(0,0,0,0.7)]'
           />
         </MainCard.Root>
+        <MainCard.Root
+          bannerImageUrl='https://images.unsplash.com/photo-1506744038136-46273834b3fb?auto=format&fit=crop&w=1000&q=80'
+          category='식음료'
+          className='w-[265px]'
+          price={200000}
+          rating={4.8}
+          reviewCount={121}
+          title='스카이다이빙'
+        >
+          <MainCard.Image className='rounded-t-3xl brightness-90 contrast-125' />
+          <MainCard.Content />
+        </MainCard.Root>
       </div>
 
       <DocCode
-        code={`         <MainCard
+        code={`         <MainCard.Root
           bannerImageUrl='https://images.unsplash.com/photo-1506744038136-46273834b3fb?auto=format&fit=crop&w=1000&q=80'
           className='w-[265px]'
           price={200000}
           rating={4.8}
           reviewCount={121}
+          category="식음료"
           title='스카이다이빙'
         >
           <MainCard.Image className='rounded-t-3xl brightness-90 contrast-125' />
@@ -111,7 +126,7 @@ Main에서 쓰이는 인기체험 모든체험 Card입니다.
             ratingClassName='text-emerald-300 font-semibold'
             priceClassName='text-pink-400 font-bold text-lg'
           />
-        </MainCard>`}
+        </MainCard.Root>`}
       />
     </>
   );


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- #216

## 📌 작업 내용
<!-- 해당 PR의 변경 사항을 자세하게 적어주세요.-->

- 메인카드 컨텐트영역 맨위에 카테고리 추가
- 메인카드 h-340으로 수정
- 메인 카드 맨위에 카테고리가 추가되면서 흰색부분이 커져 이미지륾 많이 가리게 되어서 메인카드를  기존 h-300에서 h-340으로 크기를 키웠습니다
- 밑에 영상 2개있는데 첫번째 영상에서 DefaultLayout은 max-w-6xl이고 2번쨰는 max-w-7xl인데 이건 나중에 같이 얘기해봐야할거같습니다!

## ✅ 체크리스트

- [x] PR 하기 전에 이슈에서 빼먹은건 없는지 확인했습니다
  - [x] 라벨 및 마일스톤을 사이드 탭에서 등록했습니다.
- [x] PR을 보내는 브랜치가 올바른지 확인했습니다.
- [x] 팀원들이 리뷰하기 쉽도록 설명을 자세하게 작성했습니다.
- [x] 변경사항을 충분히 테스트 했습니다.
- [x] (함수를 구현 했을 때) JSDoc을 양식에 맞춰서 작성했습니다.
- [x] 컨벤션에 맞게 구현했습니다.

## 📷 UI 변경 사항 (선택)
<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->

- 

https://github.com/user-attachments/assets/d4a3f603-42a8-4a4d-84e7-0a486358042f




https://github.com/user-attachments/assets/264cdd95-3c5e-4949-90e4-166940740e56

d57



## ❓무슨 문제가 발생했나요? (선택)

-

## 💬 기타 참고 사항 (선택)
<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->

-
