### PR TITLE
라디오 애니메이션 제거

### DIFF
--- a/packages/design-system/src/components/RadioGroup/RadioGroup.tsx
+++ b/packages/design-system/src/components/RadioGroup/RadioGroup.tsx
@@ -101,7 +101,6 @@ export default function RadioGroup({
       <motion.div
         animate={{ x: 0, opacity: 1 }}
         className={twMerge('no-scrollbar flex flex-nowrap gap-4 overflow-x-auto scroll-smooth', radioGroupClassName)}
-        initial={{ x: -20, opacity: 0 }}
         style={{
           scrollbarWidth: 'none',
           msOverflowStyle: 'none',


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- #222

## 📌 작업 내용
<!-- 해당 PR의 변경 사항을 자세하게 적어주세요.-->

- 기존에 라디오가 왼쪽에서 오른쪽으로 슈루룩 나오는 애니메이션 있었는데 제거했습니다.

## ✅ 체크리스트

- [x] PR 하기 전에 이슈에서 빼먹은건 없는지 확인했습니다
  - [x] 라벨 및 마일스톤을 사이드 탭에서 등록했습니다.
- [x] PR을 보내는 브랜치가 올바른지 확인했습니다.
- [x] 팀원들이 리뷰하기 쉽도록 설명을 자세하게 작성했습니다.
- [x] 변경사항을 충분히 테스트 했습니다.
- [x] (함수를 구현 했을 때) JSDoc을 양식에 맞춰서 작성했습니다.
- [x] 컨벤션에 맞게 구현했습니다.

## 📷 UI 변경 사항 (선택)
<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->

- 

## ❓무슨 문제가 발생했나요? (선택)

-

## 💬 기타 참고 사항 (선택)
<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * RadioGroup 컴포넌트의 애니메이션 효과가 자연스럽게 변경되었습니다.  
    (초기 위치 및 투명도 설정이 제거되어 더욱 부드러운 전환이 적용됩니다.)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->