### PR TITLE
메인페이지 스켈레톤 구현

### DIFF
--- a/packages/design-system/src/components/Carousel/Carousel.tsx
+++ b/packages/design-system/src/components/Carousel/Carousel.tsx
@@ -1,26 +1,12 @@
 import { motion } from 'motion/react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import { MainCard } from '../MainCard';
 import NavigationButton from './NavigationButton';
 import type { CarouselProps, Props } from './types';
 
-export default function Carousel({ items, itemsPerPage: initialItemsPerPage = 4, onClick }: Props<CarouselProps>) {
+export default function Carousel({ items, itemsPerPage, onClick }: Props<CarouselProps>) {
   const [page, setPage] = useState(0);
-  const [itemsPerPage, setItemsPerPage] = useState(initialItemsPerPage);
-
-  useEffect(() => {
-    const handleResize = () => {
-      const width = window.innerWidth;
-      if (width < 768) return;
-      else if (width < 1024) setItemsPerPage(2);
-      else setItemsPerPage(4);
-    };
-
-    handleResize();
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
-  }, []);
 
   const totalPages = Math.ceil(items.length / itemsPerPage);
   const itemWidthPercent = 100 / itemsPerPage;

--- a/packages/design-system/src/components/MainPageSkeleton/MainPageSkeleton.tsx
+++ b/packages/design-system/src/components/MainPageSkeleton/MainPageSkeleton.tsx
@@ -1,0 +1,121 @@
+import { useEffect, useState } from 'react';
+import { twMerge } from 'tailwind-merge';
+
+interface SkeletonProps {
+  className?: string;
+}
+export function Skeleton({ className }: SkeletonProps) {
+  return <div className={twMerge('animate-pulse rounded-lg bg-gray-100', className)} />;
+}
+
+// 단일 카드 스켈레톤
+export function ActivityCardSkeleton() {
+  return (
+    <div className='relative w-full'>
+      <Skeleton className='h-260 w-full rounded-xl border border-gray-50 md:h-366 lg:h-340' />
+      <div className='absolute bottom-0 left-0 w-full'>
+        <div
+          className={twMerge(
+            'flex flex-col gap-8 rounded-xl border border-gray-50 bg-white',
+            'px-20 py-12 md:px-20 md:py-30 lg:py-15',
+          )}
+        >
+          <Skeleton className='h-16 w-1/3' />
+          <Skeleton className='h-16 w-3/4' />
+          <div className='flex items-center gap-8'>
+            <Skeleton className='h-14 w-14 rounded-full' />
+            <Skeleton className='h-14 w-12' />
+            <Skeleton className='h-14 w-12' />
+          </div>
+          <Skeleton className='h-16 w-1/2' />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// 반응형 스켈레톤 개수 계산
+const getResponsiveCount = () => {
+  const w = window.innerWidth;
+  if (w < 768) return 6; // 모바일
+  if (w < 1280) return 4; // 태블릿
+  return 8; // 데스크탑
+};
+
+export function ActivityCardGridSkeleton() {
+  const [count, setCount] = useState(() => getResponsiveCount());
+
+  useEffect(() => {
+    const onResize = () => setCount(getResponsiveCount());
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, []);
+
+  return (
+    <>
+      {Array.from({ length: count }).map((_, i) => (
+        <ActivityCardSkeleton key={i} />
+      ))}
+    </>
+  );
+}
+
+// Carousel용 스켈레톤 (인기 체험 반응형)
+
+interface CarouselSkeletonProps {
+  count?: number;
+}
+export function CarouselSkeleton({ count = 4 }: CarouselSkeletonProps) {
+  const MOBILE_BREAK = 768;
+  const TABLET_BREAK = 1280;
+
+  const getInitial = () => {
+    const w = window.innerWidth;
+    if (w < MOBILE_BREAK) return count;
+    if (w < TABLET_BREAK) return 2;
+    return count;
+  };
+
+  const [perPage, setPerPage] = useState(() => getInitial());
+
+  useEffect(() => {
+    const onResize = () => setPerPage(getInitial());
+    // 마운트 시 한 번 실행
+    onResize();
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, [count]);
+
+  return (
+    <div className='relative w-full overflow-visible'>
+      <div className='relative mx-auto'>
+        {/* 태블릿·데스크탑 */}
+        <div className='relative hidden w-full overflow-hidden md:block'>
+          <div className='flex'>
+            {Array.from({ length: perPage }).map((_, i) => (
+              <div
+                key={i}
+                className={twMerge('box-border shrink-0', i !== perPage - 1 ? 'pr-10' : '')}
+                style={{ width: `${100 / perPage}%` }}
+              >
+                <ActivityCardSkeleton />
+              </div>
+            ))}
+          </div>
+        </div>
+        {/* 모바일 */}
+        <div
+          className='flex w-full gap-6 overflow-x-auto px-4 md:hidden'
+          style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' }}
+        >
+          <style>{`div::-webkit-scrollbar { display: none; }`}</style>
+          {Array.from({ length: count }).map((_, i) => (
+            <div key={i} className='w-265 shrink-0'>
+              <ActivityCardSkeleton />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/design-system/src/components/MainPageSkeleton/index.ts
+++ b/packages/design-system/src/components/MainPageSkeleton/index.ts
@@ -1,0 +1,3 @@
+export { ActivityCardSkeleton } from './MainPageSkeleton';
+export { ActivityCardGridSkeleton } from './MainPageSkeleton';
+export { CarouselSkeleton } from './MainPageSkeleton';

--- a/packages/design-system/src/components/index.ts
+++ b/packages/design-system/src/components/index.ts
@@ -14,6 +14,7 @@ export * from './input';
 export * from './logos';
 export { default as MainBanner } from './MainBanner/MainBanner';
 export * from './MainCard';
+export * from './MainPageSkeleton';
 export { default as MainSearchInput } from './MainSearchInput/MainSearchInput';
 export * from './modal';
 export { default as NoResult } from './NoResult';

--- a/packages/design-system/src/layouts/Sidebar.tsx
+++ b/packages/design-system/src/layouts/Sidebar.tsx
@@ -47,6 +47,7 @@ export default function DesignSystemLayout() {
             <SidebarNavItem label='MypageSummaryCard' to='/docs/MypageSummaryCard' />
             <SidebarNavItem label='UpcomingSchedule' to='/docs/UpcomingSchedule' />
             <SidebarNavItem label='OngoingExperienceCard' to='/docs/OngoingExperienceCard' />
+            <SidebarNavItem label='MainPageSkeleton' to='/docs/MainPageSkeleton' />
           </ul>
         </nav>
       </aside>

--- a/packages/design-system/src/pages/MainPageSkeletonDoc.tsx
+++ b/packages/design-system/src/pages/MainPageSkeletonDoc.tsx
@@ -1,0 +1,54 @@
+import Playground from '@/layouts/Playground';
+
+import { ActivityCardGridSkeleton, CarouselSkeleton } from '../components/MainPageSkeleton/MainPageSkeleton';
+import DocTemplate, { DocCode } from '../layouts/DocTemplate';
+
+/* Playground에서 사용할 예시 코드 */
+const code = `
+<>
+  {/* 인기 체험 섹션 */}
+  <section>
+    <h2 className='mb-12 text-2xl font-bold'>인기 체험</h2>
+    <CarouselSkeleton count={4} />
+  </section>
+
+  {/* 모든 체험 섹션 */}
+  <section className='mt-32'>
+    <h2 className='mb-12 text-2xl font-bold'>모든 체험</h2>
+    <div className='grid grid-cols-2 gap-12 md:grid-cols-2 xl:grid-cols-4'>
+      <ActivityCardGridSkeleton />
+    </div>
+  </section>
+</>
+`;
+
+export default function MainPageSkeletonDoc() {
+  return (
+    <>
+      <DocTemplate
+        description={`
+# MainPageSkeleton 컴포넌트
+
+MainPageSkeleton은 반응형 레이아웃에 맞춰 카드 스켈레톤을 표시하는 컴포넌트입니다.
+
+- **ActivityCardGridSkeleton** : 메인 페이지 전체 카드 리스트 로딩 상태에서 사용
+- **CarouselSkeleton** : 인기 체험 섹션 등 캐러셀 레이아웃 로딩 상태에서 사용
+`}
+        propsDescription={`
+| 이름 | 타입 | 설명 |
+|------|------|------|
+| count | number | 캐러셀에서 한 번에 보여줄 카드 개수 (기본값: 4) |
+`}
+        title='MainPageSkeleton'
+      />
+
+      {/* 예시 코드 */}
+      <DocCode code={code} />
+
+      {/* Playground */}
+      <div className='mt-24'>
+        <Playground code={code} scope={{ ActivityCardGridSkeleton, CarouselSkeleton }} />
+      </div>
+    </>
+  );
+}

--- a/packages/design-system/src/routes/index.tsx
+++ b/packages/design-system/src/routes/index.tsx
@@ -14,6 +14,7 @@ import LandingPage from '@pages/LandingPage';
 import LogoDoc from '@pages/LogoDoc';
 import MainBannerDoc from '@pages/MainBannerDoc';
 import MainCardDoc from '@pages/MainCardDoc';
+import MainPageSkeletonDoc from '@pages/MainPageSkeletonDoc';
 import MainSearchInputDoc from '@pages/MainSearchInputDoc';
 import ModalDoc from '@pages/ModalDoc';
 import MypageProfileHeaderDoc from '@pages/MypageProfileHeaderDoc';
@@ -195,6 +196,10 @@ const router = createBrowserRouter([
       {
         path: 'AddressInput',
         element: <AddressInputDoc />,
+      },
+      {
+        path: 'MainPageSkeleton',
+        element: <MainPageSkeletonDoc />,
       },
     ],
   },


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- #224

## 📌 작업 내용
<!-- 해당 PR의 변경 사항을 자세하게 적어주세요.-->

- 메인페이지 스켈레톤 추가

## ✅ 체크리스트

- [x] PR 하기 전에 이슈에서 빼먹은건 없는지 확인했습니다
- [x] 라벨 및 마일스톤을 사이드 탭에서 등록했습니다.
- [x] PR을 보내는 브랜치가 올바른지 확인했습니다.
- [x] 팀원들이 리뷰하기 쉽도록 설명을 자세하게 작성했습니다.
- [x] 변경사항을 충분히 테스트 했습니다.
- [x] (함수를 구현 했을 때) JSDoc을 양식에 맞춰서 작성했습니다.
- [x] 컨벤션에 맞게 구현했습니다.

## 📷 UI 변경 사항 (선택)
<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->

- 

https://github.com/user-attachments/assets/0ac17276-b758-483f-bba4-4e29ee2b66a6



## ❓무슨 문제가 발생했나요? (선택)

-

## 💬 기타 참고 사항 (선택)
<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 메인 페이지와 인기 활동 섹션에 로딩 상태를 위한 스켈레톤 UI가 추가되었습니다.
  * 다양한 스켈레톤 컴포넌트(카드, 그리드, 캐러셀)가 반응형으로 제공됩니다.
  * 디자인 시스템 문서에 스켈레톤 컴포넌트 사용 예시 및 Playground가 추가되었습니다.

* **개선 사항**
  * 창 크기에 따라 카드 표시 개수가 자동으로 조정됩니다.
  * 로딩 중에만 스켈레톤 UI가 표시되고, 데이터가 준비되면 실제 콘텐츠가 나타납니다.
  * 인기 활동 캐러셀 및 카드 그리드의 정렬 및 페이징 로직이 간소화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->