### PR TITLE
체험 등록의 이미지 등록시 파일 크기 제한

### DIFF
--- a/apps/what-today/src/components/experiences/ImageInput.tsx
+++ b/apps/what-today/src/components/experiences/ImageInput.tsx
@@ -1,4 +1,4 @@
-import { Button, DeleteIcon, PlusIcon } from '@what-today/design-system';
+import { Button, DeleteIcon, PlusIcon, useToast } from '@what-today/design-system';
 import { useId, useRef } from 'react';
 import { twMerge } from 'tailwind-merge';
 
@@ -17,6 +17,7 @@ type ImageInputProps =
     };
 
 export default function ImageInput({ value, onChange, max, className }: ImageInputProps) {
+  const { toast } = useToast();
   const inputRef = useRef<HTMLInputElement>(null);
   const id = useId();
   let urls: string[] = [];
@@ -30,6 +31,25 @@ export default function ImageInput({ value, onChange, max, className }: ImageInp
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
+
+    const MAX_FILE_SIZE = 5 * 1024 * 1024; // 파일 최대 크기 5MB
+    if (file.size > MAX_FILE_SIZE) {
+      toast({
+        title: '이미지 업로드 오류',
+        description: '파일 크기는 5MB 이하여야 합니다',
+        type: 'error',
+      });
+      return;
+    }
+
+    if (!file.type.startsWith('image/')) {
+      toast({
+        title: '이미지 업로드 오류',
+        description: '이미지 파일만 업로드 가능합니다',
+        type: 'error',
+      });
+      return;
+    }
 
     const url = URL.createObjectURL(file);
 

--- a/packages/design-system/src/components/ProfileImageInput.tsx
+++ b/packages/design-system/src/components/ProfileImageInput.tsx
@@ -1,6 +1,7 @@
 import Button from '@components/button';
 import { DeleteIcon } from '@components/icons';
 import { ProfileLogo } from '@components/logos';
+import { useToast } from '@components/Toast';
 import { useCallback, useEffect, useState } from 'react';
 
 interface ProfileImageInputProps {
@@ -70,6 +71,7 @@ export function DeleteButton({ onDelete }: { onDelete: () => void }) {
  * @param {(value: string) => void} onChange - 이미지가 변경되었을 때 호출되는 콜백 함수. base64 string 또는 URL을 인자로 받습니다.
  */
 export default function ProfileImageInput({ src, initial = src, onChange }: ProfileImageInputProps) {
+  const { toast } = useToast();
   const [initialSrc, setInitialSrc] = useState(initial);
   const [previewUrl, setPreviewUrl] = useState<string>(src);
 
@@ -88,12 +90,20 @@ export default function ProfileImageInput({ src, initial = src, onChange }: Prof
 
     const MAX_FILE_SIZE = 5 * 1024 * 1024; // 파일 최대 크기 5MB
     if (file.size > MAX_FILE_SIZE) {
-      alert('파일 크기는 5MB 이하여야 합니다.');
+      toast({
+        title: '이미지 업로드 오류',
+        description: '파일 크기는 5MB 이하여야 합니다',
+        type: 'error',
+      });
       return;
     }
 
     if (!file.type.startsWith('image/')) {
-      alert('이미지 파일만 업로드 가능합니다.');
+      toast({
+        title: '이미지 업로드 오류',
+        description: '이미지 파일만 업로드 가능합니다',
+        type: 'error',
+      });
       return;
     }
 


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- #240

## 📌 작업 내용
<!-- 해당 PR의 변경 사항을 자세하게 적어주세요.-->

- 체험 등록의 이미지 등록시 파일 크기를 5MB로 제한했습니다. 
- 프로필 이미지 등록시 alert으로 메시지가 뜨는 것도 토스트 메시지로 변경했습니다.

## ✅ 체크리스트

- [x] PR 하기 전에 이슈에서 빼먹은건 없는지 확인했습니다
  - [x] 라벨 및 마일스톤을 사이드 탭에서 등록했습니다.
- [x] PR을 보내는 브랜치가 올바른지 확인했습니다.
- [x] 팀원들이 리뷰하기 쉽도록 설명을 자세하게 작성했습니다.
- [x] 변경사항을 충분히 테스트 했습니다.
- [x] (함수를 구현 했을 때) JSDoc을 양식에 맞춰서 작성했습니다.
- [x] 컨벤션에 맞게 구현했습니다.

## 📷 UI 변경 사항 (선택)
<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->

<img width="400" alt="IMG_0036" src="https://github.com/user-attachments/assets/1671abe0-0b9e-4834-85e6-3a53bf0b277e" />


## ❓무슨 문제가 발생했나요? (선택)

-

## 💬 기타 참고 사항 (선택)
<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->

-
