### PR TITLE
DefaultLayout 통일하기

### DIFF
--- a/apps/what-today/src/components/FloatingTranslateButton.tsx
+++ b/apps/what-today/src/components/FloatingTranslateButton.tsx
@@ -330,7 +330,7 @@ const FloatingTranslateButton: React.FC<FloatingTranslateButtonProps> = ({ class
       <div ref={containerRef} className={twMerge('fixed right-10 bottom-10 z-45', className)}>
         {/* 언어 선택 드롭다운 */}
         {isOpen && (
-          <div className='absolute right-0 bottom-50 flex h-300 w-160 transform flex-col rounded-xl border border-gray-50 bg-white p-10 shadow-[0px_4px_24px_rgba(156,180,202,0.2)] transition-all duration-200 ease-out'>
+          <div className='absolute right-0 bottom-50 flex h-300 w-170 transform flex-col rounded-xl border border-gray-50 bg-white p-10 shadow-[0px_4px_24px_rgba(156,180,202,0.2)] transition-all duration-200 ease-out'>
             <div className='caption-text mb-2 p-2 text-gray-400'>언어 선택</div>
             <div className='mr-4 flex-1 space-y-4 overflow-y-auto px-3 py-2'>
               {languages.map((language) => (

--- a/apps/what-today/src/components/MypageSidebar.tsx
+++ b/apps/what-today/src/components/MypageSidebar.tsx
@@ -56,7 +56,7 @@ export default function MypageSidebar({ onLogoutClick, onClick, isOpen }: Mypage
     <nav
       className={twMerge(
         // 공통 스타일
-        'fixed z-50 max-w-200 min-w-200 rounded-2xl border border-gray-50 bg-white transition duration-300 md:static md:h-fit xl:w-280',
+        'fixed top-62 z-50 max-w-200 min-w-200 rounded-2xl border border-gray-50 bg-white transition duration-300 md:static md:h-fit xl:w-280',
         // 모바일에서 Drawer 위치
         isOpen ? 'translate-x-0' : 'h-100 -translate-x-full bg-gray-200',
         'md:translate-x-0',

--- a/apps/what-today/src/layouts/DefaultLayout.tsx
+++ b/apps/what-today/src/layouts/DefaultLayout.tsx
@@ -17,12 +17,12 @@ export default function DefaultLayout() {
   const floatingButtonClass = !isDesktop && isActivityDetailPage ? 'bottom-160' : undefined;
 
   return (
-    <div className='flex w-full min-w-375 flex-col items-center gap-8'>
+    <div className='flex min-h-screen w-full min-w-375 flex-col items-center gap-8'>
       <header className='w-full max-w-7xl px-[5vw]'>
         <Header />
       </header>
 
-      <main className='w-full max-w-7xl px-16 sm:px-24 md:px-32 lg:px-48'>
+      <main className='w-full max-w-7xl flex-grow px-16 sm:px-24 md:px-32 lg:px-48'>
         <Outlet />
       </main>
 

--- a/apps/what-today/src/layouts/DefaultLayout.tsx
+++ b/apps/what-today/src/layouts/DefaultLayout.tsx
@@ -1,5 +1,6 @@
 import { Footer } from '@what-today/design-system';
 import { Outlet, useLocation } from 'react-router-dom';
+import { twJoin } from 'tailwind-merge';
 
 import FloatingTranslateButton from '@/components/FloatingTranslateButton';
 import Header from '@/components/Header';
@@ -10,27 +11,22 @@ export default function DefaultLayout() {
   const { isDesktop } = useResponsive();
   const isActivityDetailPage = location.pathname.startsWith('/activities/');
 
-  const footerMarginBottom = isActivityDetailPage && !isDesktop ? 'w-full mb-125' : 'w-full';
+  // const footerMarginBottom = isActivityDetailPage && !isDesktop ? 'w-full mb-120' : 'w-full';
 
   // FloatingTranslateButton의 bottom 위치 조건부 설정
   const floatingButtonClass = !isDesktop && isActivityDetailPage ? 'bottom-160' : undefined;
 
   return (
-    <div className='flex w-full flex-col items-center gap-8 overflow-x-hidden'>
+    <div className='flex w-full flex-col items-center gap-8'>
       <header className='w-full max-w-7xl px-[5vw]'>
         <Header />
       </header>
-      <main
-        className={`min-h-[90vh] w-full ${
-          isActivityDetailPage
-            ? 'max-w-7xl px-16 sm:px-24 md:px-32 lg:px-48 xl:max-w-7xl' // 상세 페이지: 반응형 패딩
-            : 'max-w-6xl px-[5vw] xl:max-w-5xl' // 기본 페이지: 기존 스타일
-        }`}
-      >
+
+      <main className='w-full max-w-7xl px-16 sm:px-24 md:px-32 lg:px-48'>
         <Outlet />
       </main>
 
-      <div className={footerMarginBottom}>
+      <div className={twJoin('w-full', isActivityDetailPage && !isDesktop && 'mb-120', 'mt-30')}>
         <Footer />
       </div>
 

--- a/apps/what-today/src/layouts/DefaultLayout.tsx
+++ b/apps/what-today/src/layouts/DefaultLayout.tsx
@@ -17,7 +17,7 @@ export default function DefaultLayout() {
   const floatingButtonClass = !isDesktop && isActivityDetailPage ? 'bottom-160' : undefined;
 
   return (
-    <div className='flex w-full flex-col items-center gap-8'>
+    <div className='flex w-full min-w-375 flex-col items-center gap-8'>
       <header className='w-full max-w-7xl px-[5vw]'>
         <Header />
       </header>

--- a/apps/what-today/src/layouts/Mypage.tsx
+++ b/apps/what-today/src/layouts/Mypage.tsx
@@ -28,7 +28,7 @@ export default function MyPageLayout() {
   }, [location.pathname]);
 
   return (
-    <div className='flex h-full w-full flex-col md:flex-row md:gap-30'>
+    <div className='flex h-full w-full flex-col justify-center md:flex-row md:gap-30'>
       {/* 모바일: 오버레이 배경 */}
       {isSidebarOpen && (
         <div className='fixed inset-0 z-50 bg-black/30 md:hidden' onClick={() => setSidebarOpen(false)} />
@@ -40,7 +40,7 @@ export default function MyPageLayout() {
         onLogoutClick={handleLogout}
       />
       <Button
-        className={twMerge('fixed top-92 left-4 z-55 w-fit p-0 md:hidden', isSidebarOpen && 'hidden')}
+        className={twMerge('fixed top-92 left-3 z-55 w-fit p-0 md:hidden', isSidebarOpen && 'hidden')}
         size='xs'
         variant='none'
         onClick={() => setSidebarOpen(true)}

--- a/apps/what-today/src/pages/activities/index.tsx
+++ b/apps/what-today/src/pages/activities/index.tsx
@@ -101,7 +101,7 @@ export default function ActivityDetailPage() {
               <Divider />
               <ReviewSection activityId={activity.id} />
             </div>
-            <div className='sticky top-16 flex h-fit flex-col gap-38'>
+            <div className='flex flex-col gap-38'>
               <ActivitiesInformation
                 address={activity.address}
                 category={activity.category}
@@ -112,13 +112,15 @@ export default function ActivityDetailPage() {
                 reviewCount={activity.reviewCount}
                 title={activity.title}
               />
-              <ReservationForm
-                activityId={activity.id}
-                isAuthor={user?.id ? activity?.userId === user.id : false}
-                isLoggedIn={!!user}
-                price={activity.price}
-                schedules={activity.schedules}
-              />
+              <div className='sticky top-16'>
+                <ReservationForm
+                  activityId={activity.id}
+                  isAuthor={user?.id ? activity?.userId === user.id : false}
+                  isLoggedIn={!!user}
+                  price={activity.price}
+                  schedules={activity.schedules}
+                />
+              </div>
             </div>
           </div>
         ) : (

--- a/packages/design-system/src/components/Footer.tsx
+++ b/packages/design-system/src/components/Footer.tsx
@@ -37,7 +37,28 @@ export default function Footer() {
             </a>
           </div>
 
-          <p>© CODEIT FE 15</p>
+          <p className='space-x-2 text-center text-sm text-gray-500'>
+            <a
+              aria-label='JIHYUN GitHub'
+              href='https://github.com/kjhyun0830'
+              rel='noopener noreferrer'
+              target='_blank'
+            >
+              지현
+            </a>
+            <span>|</span>
+            <a aria-label='TAEIL GitHub' href='https://github.com/Taeil08' rel='noopener noreferrer' target='_blank'>
+              태일
+            </a>
+            <span>|</span>
+            <a aria-label='JIWOO GitHub' href='https://github.com/MyungJiwoo' rel='noopener noreferrer' target='_blank'>
+              지우
+            </a>
+            <span>|</span>
+            <a aria-label='JISEOP GitHub' href='https://github.com/HarrySeop' rel='noopener noreferrer' target='_blank'>
+              지섭
+            </a>
+          </p>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- #263 

## 📌 작업 내용
<!-- 해당 PR의 변경 사항을 자세하게 적어주세요.-->

- 레이아웃을 통일 했습니다.
- 플로팅 버튼 눌렀을 때 영역에 x스크롤 생기는 이슈 때문에 너비를 늘렸습니다.

## ✅ 체크리스트

- [x] PR 하기 전에 이슈에서 빼먹은건 없는지 확인했습니다
  - [x] 라벨 및 마일스톤을 사이드 탭에서 등록했습니다.
- [x] PR을 보내는 브랜치가 올바른지 확인했습니다.
- [x] 팀원들이 리뷰하기 쉽도록 설명을 자세하게 작성했습니다.
- [x] 변경사항을 충분히 테스트 했습니다.
- [x] (함수를 구현 했을 때) JSDoc을 양식에 맞춰서 작성했습니다.
- [x] 컨벤션에 맞게 구현했습니다.

## 📷 UI 변경 사항 (선택)
<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->

<img width="1174" height="764" alt="image" src="https://github.com/user-attachments/assets/72fffb54-164a-456e-90e1-06a1c14915fe" />


## ❓무슨 문제가 발생했나요? (선택)

> 졸려용

## 💬 기타 참고 사항 (선택)
<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * 플로팅 번역 버튼의 언어 선택 드롭다운 너비가 소폭 늘어났습니다.
  * 예약 폼의 고정(스티키) 위치가 조정되어, 데스크톱에서 예약 폼만 화면에 고정됩니다.
  * 일부 레이아웃 및 마진, 패딩, 오버플로우 스타일이 개선되어 페이지 배치가 더욱 일관성 있게 변경되었습니다.
  * 마이페이지 사이드바 고정 시 상단 위치가 조정되었습니다.
  * 마이페이지 레이아웃에서 세로 정렬과 고정 버튼의 좌측 위치가 조정되었습니다.
  * 푸터에 GitHub 프로필 링크가 추가되어 저작권 정보가 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->